### PR TITLE
Add verification of Fixes: tags

### DIFF
--- a/fixes-tag.md
+++ b/fixes-tag.md
@@ -1,0 +1,243 @@
+# Fixes: Tag Verification
+
+This prompt provides detailed instructions for verifying Fixes: tags when they appear in commit messages.
+
+## Purpose of Fixes: Tags
+
+A Fixes: tag indicates that a patch fixes a bug in a previous commit. The tag:
+- Makes it easy to determine where an issue originated
+- Helps reviewers understand the bug fix context
+- Assists the stable kernel team in determining which stable kernel versions should receive the fix
+- Is used by automated backporting tools (e.g., AUTOSEL)
+- Should be included even for bugs that don't require stable backporting
+
+## Pattern-specific TodoWrite fields
+
+For each Fixes: tag found in the commit message, create a TodoWrite entry:
+- Fixes tag text: [full tag as written]
+- Commit SHA-1: [the commit ID from tag]
+- SHA-1 length: [number of characters]
+- Subject in quotes: [YES/NO]
+- Single line: [YES/NO - note if wrapped]
+- Tag location: [sign-off area/below ---/other]
+- Commit exists: [YES/NO - verification command]
+- Commit reachable: [YES/NO - verification command]
+- Subject matches original: [YES/NO - show both if different]
+- Bug actually fixed: [YES/NO/UNCLEAR - reasoning]
+- Stable tag present: [YES/NO/NOT_NEEDED - reasoning]
+- Issues found: [list any problems]
+
+## Format Requirements [FIXES-001]
+
+**Risk**: Parsing failures, incorrect stable backports
+
+**Mandatory format validation:**
+
+Track each Fixes: tag in the TodoWrite and verify:
+
+1. **SHA-1 Length Check**
+   - Check that SHA-1 has minimum 12 characters
+   - Verify hexadecimal characters only
+   - Example: `c0cbe70742f4` (12 chars) ✓
+   - Counter-example: `c0cbe70` (7 chars) ✗
+   - Record SHA-1 length in TodoWrite
+
+2. **Summary Format Check**
+   - Verify subject line is enclosed in double quotes
+   - Subject line should match the original commit's first line
+   - Format: `Fixes: 12+char-SHA1 ("Original subject line")`
+   - Example: `Fixes: 54a4f0239f2e ("KVM: MMU: make kvm_mmu_zap_page() return the number of pages it actually freed")` ✓
+   - Record quote presence in TodoWrite
+
+3. **Single Line Requirement**
+   - Verify tag is NOT split across multiple lines
+   - Tags are exempt from the "wrap at 75 columns" rule to simplify
+     parsing scripts
+   - If the line is very long, it should still remain on one line
+   - Counter-example:
+     ```
+     Fixes: 54a4f0239f2e ("KVM: MMU: make kvm_mmu_zap_page()
+       return the number of pages it actually freed")
+     ```
+     This is INCORRECT - tag must be on a single line
+   - Record line wrapping status in TodoWrite
+
+4. **Subject Line Accuracy**
+   - Use `git log -1 --format=%s <commit-id>` to get original subject
+   - Compare with subject in Fixes: tag
+   - Common errors:
+     - Truncated subject line
+     - Modified or paraphrased subject
+     - Missing subsystem prefix
+   - Record comparison result in TodoWrite
+
+## Tag Placement [FIXES-002]
+
+**Risk**: Tag not recognized by automated tools
+
+**Mandatory placement validation:**
+
+Track tag location in TodoWrite and verify:
+
+1. **Location in Commit Message**
+   - Verify tag appears in the sign-off area (after main commit
+     description)
+   - Typical order: Fixes: tag appears before other attribution tags
+   - Common ordering (from maintainer-tip.rst):
+     ```
+     <commit description>
+
+     Fixes: <sha1> ("subject")
+     Reported-by: <reporter>
+     Signed-off-by: <author>
+     Reviewed-by: <reviewer>
+     ```
+   - Record tag location in TodoWrite
+
+2. **Not in Comment Section**
+   - Verify tag is above the `---` separator
+   - Tags below `---` are not included in the git commit
+   - Record separator position in TodoWrite if present
+
+## Commit Verification [FIXES-003]
+
+**Risk**: Invalid commit reference, incorrect attribution
+
+**Mandatory commit validation:**
+
+Track commit verification in TodoWrite:
+
+1. **Commit Existence**
+   - Run: `git cat-file -t <commit-id>`
+   - Verify it returns "commit"
+   - If commit doesn't exist in current tree, check if it's in Linus's
+     tree
+   - Record existence check result in TodoWrite
+
+2. **Commit Reachability**
+   - Run: `git merge-base --is-ancestor <commit-id> HEAD`
+   - Verify commit is in mainline history
+   - Note: For fixes targeting recent commits, they may be in linux-next
+     or subsystem trees
+   - Record reachability check result in TodoWrite
+
+3. **Verify the Bug Actually Exists**
+   - Read the referenced commit using git show or git log
+   - Analyze whether current patch actually fixes a bug introduced by
+     that commit
+   - Common errors to check for:
+     - Fixes: tag points to wrong commit
+     - Fixes: tag points to a commit that didn't introduce the bug
+     - Multiple commits contributed to the bug, but only one is
+       referenced
+   - Record bug relationship analysis in TodoWrite
+
+## Stable Kernel Considerations [FIXES-004]
+
+**Risk**: Missing stable backports, incorrect backport scope
+
+**Mandatory stable backport validation:**
+
+Track stable considerations in TodoWrite:
+
+1. **Fixes: Tag Does Not Guarantee Backport**
+   - Note: A Fixes: tag alone does NOT automatically trigger stable
+     backports in all subsystems
+   - Verify whether `Cc: stable@vger.kernel.org` tag is also present
+   - Some subsystems (e.g., KVM x86) opt out of automatic Fixes:
+     backporting
+   - Record stable tag presence in TodoWrite
+
+2. **Stable Tag Verification**
+   - Analyze if bug affects released kernels
+   - For regressions in the past 12 months, stable tag should be present
+   - Verify stable tag is in the sign-off area (NOT as an email Cc
+     recipient)
+   - Record stable tag assessment in TodoWrite
+
+3. **Backport Prerequisites**
+   - Check if fix depends on other commits
+   - Verify prerequisite commits are noted if present:
+     ```
+     Cc: <stable@vger.kernel.org> # 5.10.x: abc123: dependency description
+     Cc: <stable@vger.kernel.org> # 5.10.x
+     ```
+   - Record dependency analysis in TodoWrite
+
+## Common Patterns and Edge Cases
+
+### When Fixes: Tag Should Be Present
+
+1. **Bug Fixes**
+   - Fixing crashes, hangs, data corruption, security issues
+   - Fixing incorrect behavior introduced by a specific commit
+   - Even for bugs that don't need stable backporting
+
+2. **Regressions**
+   - Any user-visible regression should have a Fixes: tag
+   - Performance regressions
+   - Functionality regressions
+
+### When Fixes: Tag May Be Absent
+
+1. **Improvements Without Specific Bug**
+   - General optimizations
+   - Code refactoring (without fixing a bug)
+   - New features
+
+2. **Fixes for Very Old Code**
+   - Bug existed since initial git history
+   - Alternative: Note in commit message "bug existed since ..."
+
+3. **Multiple Contributing Commits**
+   - If multiple commits contributed to a bug, typically reference the most direct/recent cause
+   - Can include multiple Fixes: tags if necessary (rare)
+
+## Git Configuration for Reviewers
+
+To make Fixes: tag generation easier, configure git:
+
+```
+[core]
+    abbrev = 12
+[pretty]
+    fixes = Fixes: %h (\"%s\")
+```
+
+Usage: `git log -1 --pretty=fixes <commit-id>`
+
+## Mandatory Self-verification gate
+
+Before completing Fixes: tag verification, answer these questions:
+
+**Pattern-specific questions:**
+  1. How many Fixes: tags did you find in the commit message? [number]
+  2. How many Fixes: tags have TodoWrite entries? [number]
+  3. How many tags have SHA-1 shorter than 12 characters? [number]
+  4. How many tags are missing quotes around the subject? [number]
+  5. How many tags are wrapped across multiple lines? [number]
+  6. How many tags reference commits that don't exist? [number]
+  7. How many tags have subject lines that don't match the original?
+     [number]
+  8. How many tags appear below the `---` separator? [number]
+  9. Does the bug actually exist in the referenced commit(s)? [YES/NO/
+     UNCLEAR for each]
+ 10. If bug affects stable, is Cc: stable@vger.kernel.org present?
+     [YES/NO/NOT_APPLICABLE]
+
+If you cannot answer ALL questions with evidence, RESTART fixes-tag
+verification from the beginning.
+
+## Quick Reference
+
+**Correct Format:**
+```
+Fixes: 54a4f0239f2e ("KVM: MMU: make kvm_mmu_zap_page() return the number of pages it actually freed")
+```
+
+**Common Errors:**
+- Too short: `Fixes: 54a4f02 (...)`  ✗
+- Missing quotes: `Fixes: 54a4f0239f2e (KVM: MMU: ...)` ✗
+- Line wrapped: `Fixes: 54a4f0239f2e ("KVM:\n    MMU: ...")` ✗
+- Wrong section: Tag appears below `---` separator ✗
+- Missing stable tag for released bug ⚠

--- a/missing-fixes-tag.md
+++ b/missing-fixes-tag.md
@@ -1,0 +1,337 @@
+# Missing Fixes: Tag Detection
+
+This prompt identifies commits that appear to fix bugs but lack a Fixes:
+tag.
+
+## Purpose
+
+A Fixes: tag should be included when a patch fixes a bug in a previous
+commit, even if the fix doesn't require stable backporting. Missing
+Fixes: tags make it harder to:
+- Track bug origins
+- Determine stable backport scope
+- Understand fix context during code review
+- Correlate fixes with their original bugs
+
+## Pattern-specific TodoWrite fields
+
+Create a TodoWrite entry to track missing Fixes: tag detection:
+- Commit has Fixes tag: [YES/NO]
+- Subject line keywords: [list STRONG/MODERATE indicators found]
+- Body bug indicators: [list indicators found or NONE]
+- Code change patterns: [list bug fix patterns found or NONE]
+- Stable tag present: [YES/NO]
+- Reported-by present: [YES/NO]
+- Link to bug tracker: [YES/NO - show link if present]
+- Confidence level: [HIGH/MEDIUM/LOW]
+- Recommendation: [should ask about Fixes tag / note only / no action]
+- Reasoning: [explain the determination]
+
+## When to Flag Missing Fixes: Tags [MISSING-FIXES-001]
+
+**Risk**: Lost attribution, incomplete stable backports, poor git
+archaeology
+
+**Mandatory missing tag detection:**
+
+Use TodoWrite to systematically evaluate the commit.
+
+### 1. Subject Line Indicators
+
+Check if the commit subject contains bug fix keywords and record in
+TodoWrite:
+
+**Strong indicators** (very likely a bug fix):
+- fix, fixes, fixed, fixing
+- crash, oops, panic, BUG
+- deadlock, hang, lockup, stall
+- corruption, corrupt
+- leak, memory leak, refcount leak, use-after-free, UAF
+- NULL pointer, null deref, null-ptr-deref
+- race, race condition
+- off-by-one, underflow, overflow
+- regression
+- revert (if reverting a bug, not just a feature)
+
+**Moderate indicators** (might be a bug fix):
+- correct, incorrect
+- missing, add missing
+- wrong, broken
+- error, failure
+- issue, problem
+
+**Examples:**
+- "mm: fix use-after-free in folio_put()" - STRONG indicator ✓
+- "net: correct skb refcounting" - MODERATE indicator ⚠
+- "bpf: add missing null check" - MODERATE indicator ⚠
+- "fs: improve performance" - NOT a bug fix ✗
+
+Record all indicators found in TodoWrite.
+
+### 2. Commit Message Body Analysis
+
+Check the commit description for bug-related language and record in
+TodoWrite:
+
+**Strong indicators:**
+- "This fixes..."
+- "This causes [crash/corruption/...]"
+- "Without this patch..."
+- References to reported bugs (bugzilla, syzkaller, etc.)
+- Describes incorrect behavior being corrected
+- Mentions user-visible regression
+- "This broke when..." or "broke after commit..."
+
+**Moderate indicators:**
+- "This should..."
+- "We need to..." (in context of correctness)
+- Describes edge case handling
+
+**Counter-indicators** (NOT bug fixes):
+- Pure refactoring descriptions
+- Performance optimization without correctness issue
+- New feature additions
+- Code cleanup
+- Documentation updates
+
+Record all indicators found in TodoWrite.
+
+### 3. Code Change Pattern Analysis
+
+Examine the actual changes for bug fix patterns and record in TodoWrite:
+
+**Strong indicators:**
+- Adding null/bounds checks that were missing
+- Fixing lock imbalances (unlock without lock, etc.)
+- Correcting reference counting (get without put, etc.)
+- Reordering operations to fix races
+- Fixing error path cleanup
+- Adding missing error checks
+- Correcting off-by-one errors
+- Fixing memory leaks
+- Initializing previously uninitialized variables
+- Fixing use-after-free by reordering frees
+
+**Moderate indicators:**
+- Adding validation that was missing
+- Changing condition logic
+- Adjusting timeouts or thresholds
+
+**Counter-indicators:**
+- Pure code movement
+- Renaming
+- Adding new functionality
+- Obvious refactoring
+
+Record all patterns found in TodoWrite.
+
+### 4. Context Clues
+
+Check for additional evidence and record in TodoWrite:
+
+- Cc: stable@vger.kernel.org tag (without Fixes: tag)
+  - This is VERY suspicious - stable tag implies bug fix
+- Reported-by: tags (bug reports usually mean bug fixes)
+- Link: tags pointing to bug trackers
+- References to syzbot, syzkaller, or other bug finders
+- Mentions of specific kernel versions where bug appeared
+
+Record all context clues in TodoWrite.
+
+## Evaluation Framework [MISSING-FIXES-002]
+
+**Mandatory evaluation process:**
+
+Use this decision tree and record results in TodoWrite at each step:
+
+```
+1. Does subject contain STRONG bug fix keyword?
+   YES → Record in TodoWrite, set confidence HIGH
+         → Ask: "Should this have a Fixes: tag?"
+   NO → Continue to step 2
+
+2. Does subject contain MODERATE bug fix keyword?
+   YES → Record in TodoWrite
+         → Check commit body and code changes
+         → Both suggest bug fix?
+            Set confidence MEDIUM
+            Ask: "Should this have Fixes: tag?"
+         → Only one suggests bug fix?
+            Set confidence LOW, note as possible
+   NO → Continue to step 3
+
+3. Does commit body describe fixing a bug?
+   YES → Record in TodoWrite
+         → Check code changes
+         → Changes match bug fix pattern?
+            Set confidence MEDIUM
+            Ask: "Should this have Fixes: tag?"
+   NO → Continue to step 4
+
+4. Do code changes show strong bug fix patterns?
+   YES → Record in TodoWrite
+         → Check subject and body again
+         → Describes a fix but no Fixes: tag?
+            Set confidence MEDIUM
+            Ask: "Should this have Fixes: tag?"
+   NO → Continue to step 5
+
+5. Is Cc: stable@vger.kernel.org present without Fixes: tag?
+   YES → Record in TodoWrite, set confidence HIGH
+         → ALWAYS ask: "Should this have Fixes: tag?"
+   NO → Record: No Fixes: tag needed
+```
+
+Record each decision point in TodoWrite.
+
+## Exception Cases [MISSING-FIXES-003]
+
+**Mandatory exception validation:**
+
+Do NOT flag as missing when (record in TodoWrite if applicable):
+
+1. **Historical bugs**
+   - Commit message notes "bug existed since initial implementation"
+   - Bug predates git history
+   - Commit references Linux 2.4 era or earlier
+
+2. **Intentional omissions**
+   - Commit message explicitly states why no Fixes: tag
+   - Part of large refactoring series where individual commits are not
+     standalone fixes
+
+3. **Unclear causation**
+   - Bug involves complex interaction of multiple commits
+   - No single commit is clearly responsible
+   - Root cause is architecture design, not specific commit
+
+4. **Not actually bug fixes**
+   - Hardening that doesn't fix specific bug
+   - Adding error handling for theoretical future case
+   - Preventive measures without existing bug
+
+Record exception determination in TodoWrite.
+
+## Confidence Levels
+
+When flagging potentially missing Fixes: tags, indicate confidence in
+TodoWrite:
+
+**High confidence** (should definitely ask):
+- STRONG keyword + bug description in body + bug fix code pattern
+- Cc: stable present without Fixes: tag
+- Reported-by: tag with clear bug report reference
+
+**Medium confidence** (worth asking):
+- MODERATE keyword + one of {bug description, bug fix pattern}
+- STRONG keyword in subject but ambiguous description
+- Clear bug fix pattern but vague commit message
+
+**Low confidence** (mention as note):
+- Only MODERATE keywords, unclear context
+- Could be hardening rather than fixing
+- Refactoring that happens to fix edge case
+
+## Question Phrasing
+
+When a Fixes: tag appears to be missing, phrase as a question:
+
+**Good phrasing:**
+- "This appears to fix a bug. Should it include a Fixes: tag?"
+- "The commit mentions a crash/corruption/leak. Would a Fixes: tag be
+  appropriate?"
+- "This has Cc: stable but no Fixes: tag. What commit introduced the
+  bug?"
+
+**Avoid:**
+- Accusatory phrasing
+- Assuming intent
+- Demanding changes
+
+**Include context:**
+- Quote the specific indicator (subject line keyword, commit message
+  text, or code pattern)
+- Explain why it looks like a bug fix
+- Note if stable backporting seems intended
+
+## Examples
+
+### Clear Missing Fixes: Tag
+
+```
+Subject: mm: add missing null check in folio_put
+
+The code crashes when folio is NULL.
+
+[code shows adding: if (!folio) return;]
+```
+**Action**: Ask about missing Fixes: tag (HIGH confidence)
+**TodoWrite**: STRONG keyword "crashes", adding null check pattern
+
+### Probable Missing Fixes: Tag
+
+```
+Subject: net: correct reference counting
+
+Cc: stable@vger.kernel.org
+
+[code shows adding missing skb_get()]
+```
+**Action**: Ask about missing Fixes: tag (HIGH confidence - has stable
+tag)
+**TodoWrite**: Stable tag present, refcount fix pattern
+
+### Possible Missing Fixes: Tag
+
+```
+Subject: bpf: improve error handling
+
+This adds better validation to prevent issues.
+
+[code shows adding bounds checks]
+```
+**Action**: Note as possible hardening vs. fix (LOW confidence)
+**TodoWrite**: MODERATE indicators, unclear if fixing existing bug
+
+### Not a Bug Fix
+
+```
+Subject: fs: refactor inode allocation
+
+Consolidate three similar functions into one helper.
+
+[code shows pure refactoring]
+```
+**Action**: No Fixes: tag needed
+**TodoWrite**: Pure refactoring, no bug indicators
+
+## Mandatory Self-verification gate
+
+Before completing missing Fixes: tag detection, answer these questions:
+
+**Pattern-specific questions:**
+  1. Is there already a Fixes: tag in the commit message? [YES/NO]
+  2. How many STRONG bug fix keywords found in subject? [number]
+  3. How many MODERATE bug fix keywords found in subject? [number]
+  4. How many bug indicators found in commit body? [number]
+  5. How many bug fix code patterns found? [number]
+  6. Is Cc: stable@vger.kernel.org present? [YES/NO]
+  7. Is Reported-by: present? [YES/NO]
+  8. Are there Links: to bug trackers? [YES/NO - list if present]
+  9. What is the confidence level? [HIGH/MEDIUM/LOW]
+ 10. What is the recommendation? [ask about Fixes / note only / no
+     action]
+ 11. Did you check for exception cases? [YES/NO - list if applicable]
+
+If you cannot answer ALL questions with evidence, RESTART
+missing-fixes-tag detection from the beginning.
+
+## Integration with Review Process
+
+This check should run:
+- **After** Task 1 (commit message is known)
+- **After** Task 2A (code changes are analyzed)
+- **Before** Task 4 (reporting phase)
+
+Add findings to the final report as questions about commit message
+completeness.

--- a/review-core.md
+++ b/review-core.md
@@ -32,6 +32,11 @@ Task 2A to make sure you've loaded all of the related categories.
 - block layer or nvme → `block.md`
 - NFSD (fs/nfsd/*, fs/lockd/*, or fs/nfs_common/*) → `nfsd.md`
 
+### Commit Message Tags (ALWAYS LOAD)
+
+- Fixes: tag in commit message → `fixes-tag.md`
+- NO Fixes: tag in commit message → `missing-fixes-tag.md`
+
 ## EXCLUSIONS
 - Ignore fs/bcachefs regressions
 - Ignore test program issues unless system crash


### PR DESCRIPTION
As part of my own patch review process, I want to verify that the Fixes: tag, if present, is correct information; In particular, I need to confirm that the listed commit hash reflects a potential culprit commit. Also, if there is no Fixes: tag, I want to check if there is a plausible culprit, if the commit appears to be a fix rather than a new feature.

This patch is an attempt to add that kind of analysis to review-prompts. Basic testing shows the new prompts are not un-useful, but I'm sure they can be improved.