### PR TITLE
networking: point Claude to Documentation/networking/statistics.rst

### DIFF
--- a/networking.md
+++ b/networking.md
@@ -63,6 +63,9 @@
 - VMADDR_PORT_ANY = -1U (must exclude from port allocation)
 - PACKET_HOST/BROADCAST/MULTICAST/OTHERHOST for pkt_type
 
+## Statistics
+- Documentation/networking/statistics.rst lays out rules for driver statistics
+
 ## Quick Checks
 - Header parsing from untrusted sources needs length validation
 - Check for htons/ntohs byte order conversions


### PR DESCRIPTION
We often have to send submitters to Documentation/networking/statistics.rst because they use custom stats instead of implementing standard ones. Tell Claude about this Documentation/ file.