### PR TITLE
RCU: add pattern for rcu removal

### DIFF
--- a/patterns/RCU-001.md
+++ b/patterns/RCU-001.md
@@ -1,0 +1,45 @@
+#### RCU-001: Remove before reclaim ordering
+
+**Risk**: Use-after-free
+
+**Details**: Objects must be removed from RCU-protected data structures before calling `call_rcu()` or `synchronize_rcu()`. The reclaim operation can be `kfree()`, releasing to a pool, or any other form of resource release.
+
+## Correct Order
+
+1. **Remove from data structure FIRST** - prevents new readers from finding the object
+2. **call_rcu() or synchronize_rcu()** - waits for existing readers to complete
+3. **Reclaim the resource** (in callback or after synchronize_rcu)
+
+Use the appropriate removal helpers: `hlist_del_rcu()`, `list_del_rcu()`, `rhashtable_remove_fast()`, etc.
+
+## WRONG pattern (causes UAF)
+
+```c
+call_rcu(&obj->rcu, free_callback);
+
+// In callback:
+void free_callback(struct rcu_head *rhp) {
+    struct obj *obj = container_of(rhp, struct obj, rcu);
+    remove_from_data_structure(obj);  // WRONG: too late!
+    kfree(obj);
+}
+```
+
+**Why this is wrong:** New RCU readers that start AFTER the grace period but BEFORE `remove_from_data_structure()` executes can still find the object via lookup. When `kfree()` runs, these readers access freed memory.
+
+## CORRECT pattern
+
+```c
+hlist_del_rcu(&obj->node);  // No new readers can find it
+call_rcu(&obj->rcu, free_callback);
+
+// In callback:
+void free_callback(struct rcu_head *rhp) {
+    struct obj *obj = container_of(rhp, struct obj, rcu);
+    kfree(obj);  // Safe: all readers done
+}
+```
+
+## Key Principle
+
+`call_rcu()` only waits for readers that existed when it was called. It provides NO protection against readers that start after the grace period. The removal must happen before `call_rcu()` to prevent new readers from finding the object.

--- a/rcu.md
+++ b/rcu.md
@@ -30,3 +30,11 @@
 - kfree_rcu() for simple object freeing
 - INIT_RCU_HEAD not needed in modern kernels
 - rcu_read_lock_held() for debug assertions
+
+## RCU Patterns [RCU]
+
+#### RCU-001: Remove before reclaim ordering
+
+**Risk**: Use-after-free
+
+**Details**: Remove from data structure before call_rcu()/synchronize_rcu(). See [patterns/RCU-001.md](patterns/RCU-001.md)


### PR DESCRIPTION
I've had a case where claude didn't understand the following race:

  Timeline:
  ─────────────────────────────────────────────────────────────────────────────

  CPU 1 (free path)                    CPU 2 (lookup path)
  ─────────────────────                ────────────────────
  free_pid()
    └─ call_rcu(&pid->rcu, delayed_put_pid)
          │
          │  [grace period passes]
          ▼
  delayed_put_pid() starts
                                       rcu_read_lock()
                                       rhashtable_lookup() → finds pid!
                                         │
  pidfs_remove_pid()  ◄────────────────  │ (pid still in table when lookup ran)
  put_pid()                              │
    └─ kmem_cache_free() ◄───────────────┤
                                         │
                                       pid_vnr(pid)  ← UAF!
                                       READ_ONCE(pid->attr) ← UAF!
                                       refcount_inc_not_zero() ← UAF!

  The critic is right. Here's the flaw in my original proof:

  My original argument assumed: If a reader holds rcu_read_lock(), the callback can't run
 concurrently.

  The actual RCU guarantee: The callback runs after all pre-existing RCU readers (those that
  existed when call_rcu() was invoked) have completed. It provides no protection for NEW
  readers that start after the grace period.

  The current code structure is:
  free_pid()
      call_rcu(&pid->rcu, delayed_put_pid);  // waits for old readers

  delayed_put_pid()
      pidfs_remove_pid(pid);   // removes from rhashtable HERE
      put_pid(pid);            // may free memory

  A new reader that starts after the grace period completes but before pidfs_remove_pid()
  executes can:
  1. Successfully find the pid via rhashtable_lookup()
  2. Have the memory freed under it when put_pid() runs

  The refcount_inc_not_zero() doesn't save us because the UAF happens before we even reach that
   check - we access pid->numbers (via pid_vnr()) and pid->attr first.

  The Correct Fix

  void free_pid(struct pid *pid)
  {
      // ... IDR removal under pidmap_lock ...
      spin_unlock(&pidmap_lock);

      pidfs_remove_pid(pid);              // Remove from rhashtable FIRST
      call_rcu(&pid->rcu, delayed_put_pid); // Then defer put_pid()
  }

  static void delayed_put_pid(struct rcu_head *rhp)
  {
      struct pid *pid = container_of(rhp, struct pid, rcu);
      put_pid(pid);  // Only this remains
  }

  This restores the correct RCU pattern:
  1. Remove from lookup structure - no new reader can find it
  2. call_rcu() - wait for existing readers to finish
  3. Free - safe because no reader has a pointer