### PR TITLE
RFC: review-core: add retrospective analysis for Fixes: tags

### DIFF
--- a/kernel/false-positive-guide.md
+++ b/kernel/false-positive-guide.md
@@ -198,6 +198,9 @@ verification checklist.
 - passing uninitialized variables to a function is fine if that function writes
 to them before reading them
 - only report reading from uninitialized variables, not writing to them.
+- `kzalloc`/`kcalloc` zero all bytes. Do not flag missing explicit
+  initialization for fields whose zero value is correct (NULL pointers,
+  zero counts, empty list heads where `*_INIT` is `{NULL}` or `{0}`).
 
 ### 13. Implicit Guard Conditions
 

--- a/kernel/review-core.md
+++ b/kernel/review-core.md
@@ -141,6 +141,15 @@ This deep dive analysis will take a long time, don't skip steps.
 
 ### Task 2: Analyze the changes for regressions
 
+0. **Reachability gate** (mandatory, before all other Task 2 work):
+   Verify that the changed code paths are reachable by the workloads
+   or consumers described in the commit message.  Check config
+   dependencies, feature flags, and protocol constraints that might
+   prevent execution.  If the code path cannot execute for the stated
+   use case, report this immediately — it is a show-stopper that
+   supersedes detailed regression analysis.
+   - Output: `REACHABILITY: confirmed` or `REACHABILITY: blocked — <reason>`
+
 1. If the patch is non-trivial: read and fully analyze callstack.md
   - **MANDATORY VALIDATION**: Have you read and callstack.md for non-trivial changes? [ y / n ]
   - verify every comment matches actual behavior


### PR DESCRIPTION
Chris suggested to me recently that you can feed old bug fixes into new prompts to see whether the updated prompts detect old bugs. It seems to me we can lubricate this process a little to help improve review patterns/prompts in a more continuous fashion. Or, at least this kind of mechanism might make it more straightforward to test changes to the prompts themselves.

This PR is only for discussion right now, because the patch itself is naive. Feel free to respond "not now" or "not appropriate" or "feedback like this is dangerous" or "already have that, use XYZ" or anything else.