### PR TITLE
Clarify kernel prompt invariants and ABI rules

### DIFF
--- a/kernel/block.md
+++ b/kernel/block.md
@@ -1,10 +1,10 @@
 - Queue Freezing Synchronization Rule: When analyzing potential races between
   bio completion paths and queue teardown functions: blk_mq_freeze_queue()
-  ensures all in-flight bios complete by waiting for q->q_usage_counter to
-  reach zero. Since every bio holds a reference to q->q_usage_counter from
-  submission (blk_try_enter_queue) to completion (blk_queue_exit), teardown
-  functions cannot complete while bios with QoS flags are still executing their
-  completion paths.
+  prevents new I/O and waits for q->q_usage_counter to reach zero. This only
+  protects teardown if the path actually takes/releases the usage ref
+  (blk_queue_enter/blk_queue_exit via blk_try_enter_queue or bio_queue_enter).
+  Custom submission/plug paths that bypass this can slip past freeze; verify
+  the accounting for the bio type you're analyzing.
 - bio chains are formed as the result of merging tests.  These establish
   rules about what bios are allowed to be mixed together.  If you find a bug
   related to chains of bios, first make sure the merging rules allows that
@@ -12,14 +12,15 @@
 
 ## Bio Mempool Allocation Guarantees
 
-Bio allocations with GFP_NOIO/GFP_NOFS cannot fail (mempool guarantee via
-`__GFP_DIRECT_RECLAIM`). ENOMEM paths only reachable with GFP_ATOMIC/GFP_NOWAIT.
+Bio allocations with GFP_NOIO/GFP_NOFS often use bioset/bvec mempools when the
+bioset was created with one. That makes ENOMEM unlikely but not impossible;
+if no mempool is present or extra allocations happen outside the pool (e.g.,
+large bvecs), failure is still possible.
 
-- `bio_alloc_bioset()` - mempool alloc, cannot fail with GFP_NOIO
-- `bvec_alloc()` - falls back to mempool with `__GFP_DIRECT_RECLAIM`
-- `bio_integrity_prep()` - uses GFP_NOIO, cannot fail
-- `bio_integrity_alloc_buf()` - uses GFP_NOFS, cannot fail
+- `bio_alloc_bioset()` - uses bioset mempool when configured; still check for NULL
+- `bvec_alloc()` - falls back to mempool only if the bioset provides it
+- `bio_integrity_prep()` - uses GFP_NOIO; may still fail without a mempool contract
+- `bio_integrity_alloc_buf()` - uses GFP_NOFS; may still fail without a mempool contract
 
 Load block specific rules:
 - **BLOCK-001** (patterns/BLOCK-001.md): Mandatory when struct bios are passed or used
-

--- a/kernel/locking.md
+++ b/kernel/locking.md
@@ -72,9 +72,9 @@ the usage is wildly wrong.
 - raw_spinlock for IRQ handlers on RT
 - Completion variables for event waiting
 - Proper memory barriers with lockless algorithms
-- atomic_read/atomic_write and other calls in this api family provide all of the
-  memory barriers needed to atomically read and write atomic_t types on every arch.
-  Don't try to find memory barrier or ordering bugs with respect to atomics.
+- atomic_read()/atomic_set() are relaxed on many archs and do NOT imply ordering.
+  If ordering matters, look for explicit smp_* barriers or acquire/release
+  atomic APIs (e.g., atomic_read_acquire/atomic_set_release).
 - percpu-rwsem for frequent read, rare write patterns
 
 ## Lock release and reaquire

--- a/kernel/rcu.md
+++ b/kernel/rcu.md
@@ -28,7 +28,7 @@
 ## Quick Checks
 - Freed memory accessible until grace period ends
 - kfree_rcu() for simple object freeing
-- INIT_RCU_HEAD not needed in modern kernels
+- INIT_RCU_HEAD is unnecessary if the rcu_head is zero-initialized; otherwise initialize it
 - rcu_read_lock_held() for debug assertions
 
 ## RCU Patterns [RCU]

--- a/kernel/scheduler.md
+++ b/kernel/scheduler.md
@@ -98,7 +98,7 @@
 - **Dispatch queues (DSQ)**: Tasks queued in local (per-CPU), global (per-node), or custom DSQs; can use FIFO or PRIQ (vtime) ordering but NOT mixed
 - **ops_state tracking**: Atomic `p->scx.ops_state` prevents concurrent BPF operations on same task; transitions: NONE → QUEUEING → QUEUED → DISPATCHING
 - **Direct dispatch**: Optimization allowing enqueue path to dispatch directly to local DSQ; tracked via per-CPU `direct_dispatch_task` marker
-- **Failsafe mechanisms**: Watchdog timeout (runnable task stalls), scx_error() on invalid ops, and SysRq-S all trigger automatic revert to CFS; system integrity always maintained
+- **Failsafe mechanisms**: Watchdog timeout (runnable task stalls), scx_error() on invalid ops, and SysRq-S are intended to trigger revert to CFS; still verify the revert path and cleanup state
 
 ## Load Balancing
 - **Pull model**: Idle CPUs pull tasks from busy CPUs

--- a/kernel/syscall.md
+++ b/kernel/syscall.md
@@ -1,2 +1,3 @@
-- Adding additional arguments to a syscall does not break ABI as long as the
-existing arguments are not changed
+- Adding arguments to an existing syscall breaks the ABI.
+- If you need more data, add a new syscall number or use an extensible struct
+  argument with a size/flags field; never change existing arguments in place.

--- a/kernel/vfs.md
+++ b/kernel/vfs.md
@@ -20,11 +20,12 @@
 
 **Details**: may_open() before file access
 
-#### VFS-004: File ops NULL check
+#### VFS-004: File ops invariant
 
 **Risk**: NULL deref
 
-**Details**: Check file->f_op != NULL before use
+**Details**: file->f_op should be non-NULL after a successful open; if code
+uses a file before open or reassigns fops, verify the invariant before use
 
 ## Inode Locking Hierarchy
 - Parent → Child ordering for directory operations
@@ -38,11 +39,12 @@
 
 ## Path Walking Modes
 - RCU-walk: Lockless, can fail and retry
-- REF-walk: Takes references, always succeeds
+- REF-walk: Takes references; avoids RCU restart, but can still fail with normal lookup errors
 - Transitions from RCU to REF on conflict
 
 ## File Operations
-- file->f_op can be NULL for special files
+- file->f_op should be non-NULL for valid open files; verify if fops are
+  reassigned or file structs are used before open
 - file_operations reassignment needs synchronization
 - Private_data lifetime tied to file lifetime
 

--- a/kernel/workqueue.md
+++ b/kernel/workqueue.md
@@ -1,3 +1,3 @@
-- once queue_work() is called, flush_work() and other workqueue shutdown
-methods prevent us from leaking the work struct on shutdown
-
+- queue_work() only schedules execution; flush_work()/flush_workqueue() wait for
+  completion or cancellation, but they do NOT free the work struct. The caller
+  owns the lifetime and must manage it explicitly.


### PR DESCRIPTION
These prompts contained absolute statements that don't match kernel behavior. Update them to align with documented semantics and common code paths.

- Syscall ABI: adding args breaks ABI; use a new syscall or extensible struct
- Atomics: atomic_read/set are relaxed; look for explicit barriers or acquire/release
- PTE states: writable+clean/!young are valid; accessed does not imply dirty
- blk-mq freeze: only covers bios that take q_usage_counter refs (enter/exit)
- Bio/mempool: pools make ENOMEM unlikely, but failure is possible without pools or extra allocs
- BPF skeleton: map FDs valid after load; prog FDs only if autoloaded
- Workqueues: flush syncs completion; it does not free the work struct
- RCU head: init is needed unless zeroed; sched_ext fallbacks are intended but verify
- VFS: f_op should be non-NULL post-open; watch reassignment paths


_Prompt: Are there any bugs in these "AI prompts for kernel review"? (Based on how you understand the Linux Kernel works.)
Created using Codex with GPT-5.2/xhigh. Verified by feeding diff into GPT-5.2/deep research: https://chatgpt.com/s/dr_6980c6f71b04819199998b1a401c2ad6_