### PR TITLE
kernel: scripts: agent/review: Provide directory and file edit permis…

### DIFF
--- a/kernel/scripts/agent_one.sh
+++ b/kernel/scripts/agent_one.sh
@@ -219,6 +219,10 @@ set_claude_opts() {
 
 	CLI_OPTS="--verbose"
 	CLI_OUT="--output-format=stream-json | tee $OUTFILE | $JSONPROG"
+	CLI_OPTS+=" --permission-mode acceptEdits"
+	CLI_OPTS+=" --add-dir /tmp"
+	CLI_OPTS+=" --add-dir $WORKING_DIR"
+	CLI_OPTS+=" --add-dir $SCRIPT_DIR/.."
 }
 
 set_copilot_opts() {

--- a/kernel/scripts/review_one.sh
+++ b/kernel/scripts/review_one.sh
@@ -215,6 +215,10 @@ set_claude_opts() {
 
 	CLI_OPTS="--verbose"
 	CLI_OUT="--output-format=stream-json | tee $OUTFILE | $JSONPROG"
+	CLI_OPTS+=" --permission-mode acceptEdits"
+	CLI_OPTS+=" --add-dir /tmp"
+	CLI_OPTS+=" --add-dir $WORKING_DIR"
+	CLI_OPTS+=" --add-dir $SCRIPT_DIR/.."
 }
 
 set_copilot_opts() {


### PR DESCRIPTION
…sions

Provide directory permissions for claude to be able to read review prompt.

For example:
<path>/review-prompts/kernel/scripts/agent_one.sh \ --linux <path_to_linux> some_sha_2dfa15ee743445436ee271d40e033deeccc3a13

I get:
I need permission to read the review-core.md file. Could you grant access to that file? In the meantime, let me proceed with a regression analysis of the commit based on what I can see.

Solutions such as providing a wrapper script with --cli would not cleanly work. Instead, just provide the path required.

Once we get past the folder permission challenge, we see:

Note: I was unable to write the review-metadata.json file due to permission restrictions. The JSON content would be:

```json
{
  "author": "Some Developer <dev@ti.com>",
  "sha": "92dfa15ee743445436ee271d40e033deeccc3a13",
  "subject": "arm64: dts: ti: k3-am62d2-evm: Add some XYZ support",
  "AI-authorship-score": "low",
  "AI-authorship-explanation": "The commit follows standard kernel DTS patterns with hardware-specific details and documentation references typical of hardware engineer contributions.",
  "issues-found": 0,
  "issue-severity-score": "none",
  "issue-severity-explanation": "No issues were found in this device tree addition."
}
```
Allow file edit permissions for claude to generate the metadata file.