### PR TITLE
kernel: lore: suggest double checking whether feedback was addressed elsewhere in the series

### DIFF
--- a/kernel/lore-thread.md
+++ b/kernel/lore-thread.md
@@ -82,7 +82,10 @@ For each review comment found:
 For comments marked as "will fix" or "Ack" by author:
 
 - Add each comment to TodoWrite
-- Check if the fix actually appears in the current HEAD commit
+- Check if the fix actually appears in the current HEAD commit.
+  If not found there, check other patches in the series — authors sometimes
+  address feedback by modifying a different patch than the one the comment
+  was on.
 - Strictly verify the fix is correct, try to disagree with any comments
   or commit messages as though you are the reviewer.  Loosen the false-positive-guide.md
   rules around trusting the author and bias toward reporting incomplete, incorrect, or


### PR DESCRIPTION
The current phrasing of lore prompts talks a lot about HEAD, which seems to make LLMs not check if feedback was addressed elsewhere in the series, even if series info was provided.

Example: 
https://netdev-ai.bots.linux.dev/ai-review.html?id=772e70cb-e06d-4968-99fd-4871bf43a348