### PR TITLE
scripts: add OpenCode setup scripts and document

### DIFF
--- a/iproute/scripts/opencode-setup.sh
+++ b/iproute/scripts/opencode-setup.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# OpenCode setup for iproute2 development
+#
+# Installs:
+#   - iproute2 skill to ~/.config/opencode/skills/iproute2/SKILL.md
+#   - Slash commands to ~/.config/opencode/commands/
+#
+# The prompts directory is determined from this script's location.
+
+set -e
+
+# Get the directory where this script lives
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The review-prompts directory is the parent of the scripts directory
+PROMPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Review prompts directory: $PROMPTS_DIR"
+echo ""
+
+# --- Install Skill ---
+
+SKILL_DIR="$HOME/.config/opencode/skills/iproute2"
+SKILL_FILE="$SKILL_DIR/SKILL.md"
+SOURCE_SKILL="$PROMPTS_DIR/skills/iproute2.md"
+
+if [ ! -f "$SOURCE_SKILL" ]; then
+    echo "Error: Source skill file not found: $SOURCE_SKILL"
+    exit 1
+fi
+
+mkdir -p "$SKILL_DIR"
+
+cp "$SOURCE_SKILL" "$SKILL_FILE"
+
+echo "Installed skill:"
+echo "  $SKILL_FILE"
+
+# --- Install Slash Commands ---
+
+COMMANDS_DIR="$HOME/.config/opencode/commands"
+SLASH_COMMANDS_SRC="$PROMPTS_DIR/slash-commands"
+
+if [ ! -d "$SLASH_COMMANDS_SRC" ]; then
+    echo "Warning: slash-commands directory not found, skipping"
+else
+    mkdir -p "$COMMANDS_DIR"
+
+    echo ""
+    echo "Installed slash commands:"
+
+    for cmd_file in "$SLASH_COMMANDS_SRC"/*.md; do
+        if [ -f "$cmd_file" ]; then
+            cmd_name=$(basename "$cmd_file")
+            cp "$cmd_file" "$COMMANDS_DIR/$cmd_name"
+            echo "  /${cmd_name%.md}"
+        fi
+    done
+fi
+
+echo ""
+echo "Setup complete!"
+echo ""
+echo "Installed into native OpenCode paths:"
+echo "  Skill:    $SKILL_FILE"
+echo "  Commands: $COMMANDS_DIR"
+echo ""
+echo "Available commands:"
+echo "  /iproute-review - Review commits for regressions"
+echo "  /iproute-debug  - Debug iproute2 crashes and issues"
+echo "  /iproute-verify - Verify findings against false positive patterns"
+echo ""
+echo "The iproute2 skill can now be discovered by OpenCode."

--- a/kernel/scripts/opencode-setup.sh
+++ b/kernel/scripts/opencode-setup.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# OpenCode setup for Linux kernel development
+#
+# Installs:
+#   - Kernel skill to ~/.config/opencode/skills/kernel/SKILL.md
+#   - Slash commands to ~/.config/opencode/commands/
+#
+# The prompts directory is determined from this script's location.
+
+set -e
+
+# Get the directory where this script lives
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The review-prompts directory is the parent of the scripts directory
+PROMPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Review prompts directory: $PROMPTS_DIR"
+echo ""
+
+# --- Install Skill ---
+
+SKILL_DIR="$HOME/.config/opencode/skills/kernel"
+SKILL_FILE="$SKILL_DIR/SKILL.md"
+SOURCE_SKILL="$PROMPTS_DIR/skills/kernel.md"
+
+if [ ! -f "$SOURCE_SKILL" ]; then
+    echo "Error: Source skill file not found: $SOURCE_SKILL"
+    exit 1
+fi
+
+mkdir -p "$SKILL_DIR"
+
+sed "s|{{KERNEL_REVIEW_PROMPTS_DIR}}|$PROMPTS_DIR|g" "$SOURCE_SKILL" > "$SKILL_FILE"
+
+echo "Installed skill:"
+echo "  $SKILL_FILE"
+
+# --- Install Slash Commands ---
+
+COMMANDS_DIR="$HOME/.config/opencode/commands"
+SLASH_COMMANDS_SRC="$PROMPTS_DIR/slash-commands"
+
+if [ ! -d "$SLASH_COMMANDS_SRC" ]; then
+    echo "Warning: slash-commands directory not found, skipping"
+else
+    mkdir -p "$COMMANDS_DIR"
+
+    echo ""
+    echo "Installed slash commands:"
+
+    for cmd_file in "$SLASH_COMMANDS_SRC"/*.md; do
+        if [ -f "$cmd_file" ]; then
+            cmd_name=$(basename "$cmd_file")
+            sed "s|REVIEW_DIR|$PROMPTS_DIR|g" "$cmd_file" > "$COMMANDS_DIR/$cmd_name"
+            echo "  /${cmd_name%.md}"
+        fi
+    done
+fi
+
+echo ""
+echo "Setup complete!"
+echo ""
+echo "Installed into native OpenCode paths:"
+echo "  Skill:    $SKILL_FILE"
+echo "  Commands: $COMMANDS_DIR"
+echo ""
+echo "Available commands:"
+echo "  /kreview    - Review a single commit for regressions"
+echo "  /kseries    - Review an entire patch series (git range) commit-by-commit"
+echo "  /korcreview - Deep dive regression analysis using ORC agent"
+echo "  /kdebug     - Debug kernel crashes and warnings"
+echo "  /kverify    - Verify findings against false positive patterns"
+echo ""
+echo "The kernel skill can now be discovered by OpenCode."

--- a/systemd/scripts/opencode-setup.sh
+++ b/systemd/scripts/opencode-setup.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# OpenCode setup for systemd development
+#
+# Installs:
+#   - systemd skill to ~/.config/opencode/skills/systemd/SKILL.md
+#   - Slash commands to ~/.config/opencode/commands/
+#
+# The prompts directory is determined from this script's location.
+
+set -e
+
+# Get the directory where this script lives
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The review-prompts directory is the parent of the scripts directory
+PROMPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Review prompts directory: $PROMPTS_DIR"
+echo ""
+
+# --- Install Skill ---
+
+SKILL_DIR="$HOME/.config/opencode/skills/systemd"
+SKILL_FILE="$SKILL_DIR/SKILL.md"
+SOURCE_SKILL="$PROMPTS_DIR/skills/systemd.md"
+
+if [ ! -f "$SOURCE_SKILL" ]; then
+    echo "Error: Source skill file not found: $SOURCE_SKILL"
+    exit 1
+fi
+
+mkdir -p "$SKILL_DIR"
+
+sed "s|{{SYSTEMD_REVIEW_PROMPTS_DIR}}|$PROMPTS_DIR|g" "$SOURCE_SKILL" > "$SKILL_FILE"
+
+echo "Installed skill:"
+echo "  $SKILL_FILE"
+
+# --- Install Slash Commands ---
+
+COMMANDS_DIR="$HOME/.config/opencode/commands"
+SLASH_COMMANDS_SRC="$PROMPTS_DIR/slash-commands"
+
+if [ ! -d "$SLASH_COMMANDS_SRC" ]; then
+    echo "Warning: slash-commands directory not found, skipping"
+else
+    mkdir -p "$COMMANDS_DIR"
+
+    echo ""
+    echo "Installed slash commands:"
+
+    for cmd_file in "$SLASH_COMMANDS_SRC"/*.md; do
+        if [ -f "$cmd_file" ]; then
+            cmd_name=$(basename "$cmd_file")
+            sed "s|REVIEW_DIR|$PROMPTS_DIR|g" "$cmd_file" > "$COMMANDS_DIR/$cmd_name"
+            echo "  /${cmd_name%.md}"
+        fi
+    done
+fi
+
+echo ""
+echo "Setup complete!"
+echo ""
+echo "Installed into native OpenCode paths:"
+echo "  Skill:    $SKILL_FILE"
+echo "  Commands: $COMMANDS_DIR"
+echo ""
+echo "Available commands:"
+echo "  /systemd-review - Review commits for regressions"
+echo "  /systemd-debug  - Debug systemd crashes and issues"
+echo "  /systemd-verify - Verify findings against false positive patterns"
+echo ""
+echo "The systemd skill can now be discovered by OpenCode."


### PR DESCRIPTION
Add native OpenCode setup helpers for kernel, systemd, and iproute so the prompts install into ~/.config/opencode. 

Note that OpenCode still needs some prompt, skill, and command behavior changes before these review workflows are fully compatible.