### PR TITLE
subsystem: clarify that File column paths are relative to subsystem/

### DIFF
--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -10,6 +10,12 @@ regexes
 
 ## Subsystem Guides
 
+> **Path resolution:** every filename in the "File" column below — and in the
+> "Optional Patterns" section — is relative to **this file's directory**:
+> `review-prompts/kernel/subsystem/`. For example,
+> `networking.md` resolves to
+> `review-prompts/kernel/subsystem/networking.md`.
+
 | Subsystem | Triggers | File |
 |-----------|----------|------|
 | Networking | net/, drivers/net/, skb_, sockets | networking.md |


### PR DESCRIPTION
kres was failing to load subsystem guides with:

  failed: No such file or directory (os error 2) path="/home/leit/Devel/review-prompts/kernel/networking.md"

The agent was resolving bare filenames like `networking.md` from the File column against the parent `kernel/` directory instead of against `subsystem/` where the files actually live. Add a header note that spells out the relative-to-this-file resolution rule so the table itself can stay terse.