### PR TITLE
Fix Codex skill installation path

### DIFF
--- a/agents/codex.sh
+++ b/agents/codex.sh
@@ -6,6 +6,6 @@
 # installed. Exports the install paths and skill filename expected by the
 # agent; additional per-agent setup steps (if any) can be added here.
 
-export SKILL_BASE_DIR="$HOME/.codex/.agents/skills"
+export SKILL_BASE_DIR="$HOME/.codex/skills"
 export COMMANDS_DIR="$HOME/.codex/prompts"
-export SKILL_FILE_NAME="AGENTS.md"
+export SKILL_FILE_NAME="SKILL.md"

--- a/kernel/scripts/codex-setup.sh
+++ b/kernel/scripts/codex-setup.sh
@@ -3,8 +3,8 @@
 # Codex setup for Linux kernel development
 #
 # Installs:
-#   - Kernel skill to ~/.codex/.agents/skills/kernel/SKILL.md
-#   - Slash commands to ~/.codex/.agents/
+#   - Kernel skill to ~/.codex/skills/kernel/SKILL.md
+#   - Slash commands to ~/.codex/prompts/
 #
 # The prompts directory is determined from this script's location.
 
@@ -21,8 +21,8 @@ echo ""
 
 # --- Install Skill ---
 
-SKILL_DIR="$HOME/.codex/.agents/skills/kernel"
-SKILL_FILE="$SKILL_DIR/AGENTS.md"
+SKILL_DIR="$HOME/.codex/skills/kernel"
+SKILL_FILE="$SKILL_DIR/SKILL.md"
 SOURCE_SKILL="$PROMPTS_DIR/skills/kernel.md"
 
 if [ ! -f "$SOURCE_SKILL" ]; then
@@ -53,7 +53,7 @@ else
     for cmd_file in "$SLASH_COMMANDS_SRC"/*.md; do
         if [ -f "$cmd_file" ]; then
             cmd_name=$(basename "$cmd_file")
-            sed "s|REVIEW_DIR|$PROMPTS_DIR|g" "$cmd_file" > "$COMMANDS_DIR/$cmd_name"
+            sed "s|{{REVIEW_DIR}}|$PROMPTS_DIR|g" "$cmd_file" > "$COMMANDS_DIR/$cmd_name"
             echo "  /$cmd_name"
         fi
     done


### PR DESCRIPTION
Codex now loads user skills from ~/.codex/skills/<name>/SKILL.md, but the Codex setup scripts were still installing to the old .agents layout as AGENTS.md. That made installed project skills invisible in /skills.

Update the Codex agent config and kernel-specific setup script to install skills into ~/.codex/skills using SKILL.md. Also fix the kernel Codex slash-command placeholder replacement to match the {{REVIEW_DIR}} template used by the command files.

Verfied with Codex and the skill is available after these changes.