### PR TITLE
kernel: Add Kconfig dependency and silent disable verification

### DIFF
--- a/kernel/review-core.md
+++ b/kernel/review-core.md
@@ -225,10 +225,11 @@ Fixes tag check for <subsystem>
 
 ### TASK 2.2 Kconfig dependency verification
 
-1. Check if the patch modifies Kconfig files or introduces new `CONFIG_*` usages in source files.
-2. If Kconfig files are modified:
+1. Check if the patch modifies Kconfig files, defconfigs, or introduces new `CONFIG_*` usages in source files.
+2. If Kconfig files or defconfigs are modified:
   - Verify that any new or modified `depends on` or `select` statements do not create circular dependencies.
   - Ensure that `select` is used safely (it does not select symbols with unmet dependencies). Prefer `depends on` over `select` for visible symbols.
+  - Check for "silent disable" issues: Ensure that when a config is enabled (e.g., via default values, selected, or in defconfigs), all of its upstream `depends on` requirements are satisfiable. Otherwise, it may appear enabled but fail to actually enable due to missing dependencies.
   - Check that new configs have appropriate help text and default values.
 3. If new `CONFIG_*` macros are used in source code:
   - Verify that the corresponding Kconfig symbol actually exists in the tree or is added in this patch/series.

--- a/kernel/review-core.md
+++ b/kernel/review-core.md
@@ -223,6 +223,17 @@ Fixes tag check for <subsystem>
     the commit being reviewed.
   - Output: Fixes: tag missing yes/no
 
+### TASK 2.2 Kconfig dependency verification
+
+1. Check if the patch modifies Kconfig files or introduces new `CONFIG_*` usages in source files.
+2. If Kconfig files are modified:
+  - Verify that any new or modified `depends on` or `select` statements do not create circular dependencies.
+  - Ensure that `select` is used safely (it does not select symbols with unmet dependencies). Prefer `depends on` over `select` for visible symbols.
+  - Check that new configs have appropriate help text and default values.
+3. If new `CONFIG_*` macros are used in source code:
+  - Verify that the corresponding Kconfig symbol actually exists in the tree or is added in this patch/series.
+4. Output: Kconfig check result (no Kconfig changes / Kconfig changes verified / Kconfig issues found)
+
 ### TASK 3: Verification []
 **Goal**: Eliminate false positives, and confirm regressions
 


### PR DESCRIPTION
  ### Description                                                                                        
                                                                                                         
  This PR introduces a new, dedicated verification step for Kconfig changes within the kernel patch      
analysis protocol. The Kconfig system has several pitfalls that can lead to broken builds or missing     
features, and these additions ensure the LLM agent proactively checks for them.                          
                                                                                                         
  ### Key Changes                                                                                        
  Added `TASK 2.2 Kconfig dependency verification` to `kernel/review-core.md`, which instructs the agent 
to:                                                                                                      
  - **Prevent Circular Dependencies:** Verify that any new or modified `depends on` or `select`          
statements do not create dependency loops.                                                               
  - **Enforce Safe `select` Usage:** Ensure `select` is not used on symbols with unmet dependencies, and 
strongly encourage the use of `depends on` for user-visible symbols.                                     
  - **Detect "Silent Disables":** Explicitly check for scenarios where a config appears enabled (e.g.,   
via `defconfig`, default values, or `select`) but fails to actually enable because its upstream `depends 
on` requirements are unsatisfied.                                                                        
  - **Validate `CONFIG_*` Macros:** Ensure that any newly introduced `CONFIG_*` macros in the source code
have corresponding Kconfig definitions either existing in the tree or added within the patch series.     
                                                                                                         
  ### Motivation                                                                                         
  Kconfig issues, particularly the "silent disable" problem where a dependency failure quietly ignores a 
`defconfig` setting, are common sources of regressions. This protocol update will make the automated     
reviews much more robust when dealing with configuration and build-system changes.             