### PR TITLE
Networking: netlink, split core from drivers, other minor updates

### DIFF
--- a/kernel/agent/orc.md
+++ b/kernel/agent/orc.md
@@ -519,7 +519,8 @@ Analyze patch file /path/to/patch.diff
 ├── callstack.md
 ├── subsystem/
 │   ├── subsystem.md
-│   ├── networking.md
+│   ├── networking-core.md
+│   ├── networking-drivers.md
 │   ├── mm.md
 │   ├── locking.md
 │   └── ...

--- a/kernel/agent/process-failed-reviews.md
+++ b/kernel/agent/process-failed-reviews.md
@@ -136,7 +136,8 @@ Examples:
 │   └── ...
 ├── subsystem/
 │   ├── subsystem.md
-│   ├── networking.md
+│   ├── networking-core.md
+│   ├── networking-drivers.md
 │   ├── drm.md
 │   ├── locking.md
 │   └── ...

--- a/kernel/subsystem/netlink.md
+++ b/kernel/subsystem/netlink.md
@@ -1,0 +1,109 @@
+# Netlink / Generic Netlink uAPI Details
+
+Source of these rules: `Documentation/userspace-api/netlink/` and
+`Documentation/core-api/netlink.rst`. Apply when reviewing changes that add
+or modify Netlink families, commands, attributes, dump callbacks, extended
+ACK reporting, or YAML specs under `Documentation/netlink/specs/`.
+
+Once a netlink message reaches user space, its layout is uAPI and cannot be
+changed. Most rules below exist because mistakes are *unfixable* after the
+first release.
+
+## Design rules for new families
+
+Following rules apply to **new families** only. If the rule is already broken
+within the family it should be ignored in future extensions of the family.
+
+- First attribute and first command ID should be `1`. Avoid type `unspec`
+  (value `0`) attribute or command
+- Use the **same command ID for request and reply** of a given operation.
+- Use a **separate command ID for each notification** so user space can route
+  notifications independently of replies.
+- New families must use the `unified` message-ID model. The `directional`
+  model is for legacy families only.
+- A `do` operation must **never** reply with multiple messages /
+  `NLM_F_MULTI`. Use a filtered dump instead.
+- `kernel-policy` should be `per-op` (the default) or `split`. Do **not** use
+  `global` for new families - it prevents per-command attribute narrowing.
+- Do not introduce new uses of request-type-specific flags
+  (`NLM_F_REPLACE`, `NLM_F_EXCL`, `NLM_F_CREATE`, `NLM_F_APPEND`,
+  `NLM_F_NONREC`, `NLM_F_BULK`, `NLM_F_ATOMIC`, `NLM_F_ROOT`,
+  `NLM_F_MATCH`). They are deprecated outside the legacy families that
+  already use them.
+
+## Replies, ACKs and notifications
+
+- All operations, especially `NEW`/`ADD`, **must reply with a full message**
+  carrying identifying information about the new object (e.g. allocated ID).
+  Once a command only ACKs, that becomes uAPI; err on the side of replying.
+  Do not rely on `NLM_F_ECHO` to convey created-object info.
+- When emitting a notification in response to a request, **pass the request
+  info to `genl_notify()`** so `NLM_F_ECHO` is honored.
+
+## Dumps
+
+- If iteration during a dump may skip or repeat objects (e.g. due to lockless
+  data structures), set `NLM_F_DUMP_INTR` on the affected message(s).
+  This is normally implemented by maintaining a generation counter and
+  recording it in `netlink_callback.seq`.
+
+## Extended ACK
+
+- Provide extended ACK info on errors **and** in the success path
+  (treated as warnings) where useful.
+- Prefer the standard attributes over plain text message if possible:
+  - `NL_SET_BAD_ATTR`      - bad attribute
+  - `NL_SET_ERR_ATTR_MISS` - missing attribute
+- If the attribute info + returned errno sufficiently explain the problem
+  the plain text message should **not** be included.
+
+## Attribute design
+
+For any new nla_get_* / nla_put_* call **always** check if the type agrees
+with the YAML spec, validation policy and with other uses.
+
+- **Prefer repeated (`multi-attr`) attributes for arrays** over nested or
+  indexed encodings. No extra wrapping nest, no `indexed-array`, no
+  `type-value` for new families.
+- **Avoid binary structures inside attributes.** Break each member into its
+  own attribute. Binary structs hurt validation and extensibility and are
+  actively discouraged for new attributes.
+- **Prefer `uint`/`sint` (variable-width 64-bit) over fixed-width** integer
+  types in most cases.
+- **Avoid integer types smaller than 32 bits** - they save no memory due to
+  the 4-byte attribute alignment. Unless the value carried is actually
+  guaranteed to be u8 or u16 (e.g. it's a protocol header field).
+- For 64-bit integers in legacy fixed structs use the `pad` attribute (only
+  one per attribute set is allowed).
+- Strings default to NUL-terminated (`NLA_NUL_STRING`); only set
+  `unterminated-ok` for legacy families. `max-len` does **not** count the
+  terminator - specs commonly write `max-len: CONST - 1`.
+
+## Validation policy
+
+- New Generic Netlink families must reject unknown attributes (this is the
+  default for new families and for those opting into strict checking).
+- Declaring the right attribute validation policy is strongly preferred
+  over open coded validation. Find ``NLA_POLICY_*`` that would have worked.
+
+## YAML spec hygiene
+
+When reviewing files under `Documentation/netlink/specs/`:
+
+- An attribute's `value` is defined only in its main set, never in a
+  `subset-of` fractional set.
+- License must be
+  `((GPL-2.0 WITH Linux-syscall-note) OR BSD-3-Clause)`.
+- Specs must be self-contained: no dependency on other specs or C headers
+  except via the `header` property for shared constants (e.g. `IFNAMSIZ`).
+- Each major property should carry a `doc`.
+- Prefer `notify:` (shares contents with a GET op) over `event:` (custom
+  subset). Events are considered less idiomatic, unless the information
+  carried is not something user will ever want to query directly (GET).
+- For `netlink-raw` sub-messages: the **selector attribute must appear before
+  the sub-message attribute** in the message; resolution uses the value
+  *closest* to the selector. Missing selector at the expected level is an
+  error.
+- YAML structs are implicitly C-packed. Natural alignment requires explicit
+  padding members - do not assume the compiler will add holes.
+- Names in YAML spec should contain dashes, not underscores (code gen converts them).

--- a/kernel/subsystem/networking-core.md
+++ b/kernel/subsystem/networking-core.md
@@ -1,4 +1,4 @@
-# Networking Subsystem Details
+# Networking Core: SKB, Sockets, and Packet Flow
 
 ## SKB Buffer Operations
 
@@ -298,112 +298,13 @@ Inconsistent family sources within a single file or subsystem suggest bugs.
 Be particularly suspicious of `x->props.family` when accessing inner packet
 properties in tunnel mode.
 
-## Ethtool Driver Statistics vs Standard Stats
-
-Adding statistics to `ethtool -S` that duplicate counters for which a
-standard kernel uAPI already exists creates confusion, leads to huge
-ethtool -S lists, and adds maintenance burden. Reviewers routinely
-reject such patches.
-
-- **Stats that have a standard uAPI must not be duplicated in `ethtool -S`.**
-  The `ethtool -S` interface (`get_ethtool_stats()` / `get_sset_count()` /
-  `get_strings()`) is for driver-private statistics only — counters that are
-  specific to the hardware or driver and have no standard representation.
-- Standard uAPIs exist for common SW-maintained and standards-defined HW
-  counters. Categories with standard interfaces include:
-  - Network device stats (`struct rtnl_link_stats64` via `ip -s link show`)
-  - Per-queue statistics (via netlink)
-  - Page pool statistics (via netlink, accessible through `ynl` tooling)
-  - Ethtool statistics (for which there is a dedicated callback in
-    `struct ethtool_ops`)
-  - Other counters exposed through standardized netlink attributes
-- A stat does not need to be currently reported by the driver to count as
-  a duplicate — if a standard uAPI exists for that category of counter,
-  the driver must use the standard interface, not `ethtool -S`.
-- When a driver wants to expose a statistic that fits an existing standard
-  category, it should implement the appropriate standard interface (e.g.,
-  `ndo_get_stats64`) rather than adding a private ethtool string.
-- `Documentation/networking/statistics.rst` documents the statistics
-  hierarchy and which interfaces to use.
-
-**REPORT as bugs**: Driver patches that add **new** counters to `ethtool -S`
-for values that have a standard uAPI — whether or not the driver currently
-reports them through that standard interface. Pre-existing `ethtool -S` stats
-that predate the standard uAPI are not bugs in new patches (migrating them is
-a separate cleanup).
-
-## Ad-hoc Synchronization with Flags and Atomics
-
-Driver code that uses atomic variables, bit flags, or boolean fields as
-substitutes for real locks or RCU almost always contains races. These
-homebrew schemes provide no actual synchronization guarantees and are
-invisible to lockdep, so the bugs they introduce go undetected by
-standard kernel debugging tools.
-
-Common broken patterns:
-
-- **Atomic/flag as gate guard**: reading an atomic or flag to decide whether
-  to proceed, then operating on shared data without holding a lock. The
-  flag's value can change immediately after the read, so the "protection"
-  is illusory.
-  ```c
-  // WRONG: intr_sem can change right after the read
-  if (atomic_read(&priv->intr_sem) != 0)
-      return;
-  // ... operates on shared state with no actual lock held
-  ```
-
-- **Bit flags as reader/writer protocol**: using `set_bit()` /
-  `test_bit()` / `clear_bit()` to coordinate access between readers and
-  a teardown path. Multiple concurrent readers can enter, one clears the
-  bit while another is still mid-operation, and the teardown path frees
-  memory that the remaining reader is still accessing.
-  ```c
-  // WRONG: concurrent readers race on the bit
-  set_bit(STATE_READ_STATS, &priv->state);
-  if (!test_bit(STATE_OPEN, &priv->state)) {
-      clear_bit(STATE_READ_STATS, &priv->state);
-      return;
-  }
-  // ... reads from shared data that close path may free
-  clear_bit(STATE_READ_STATS, &priv->state);
-  ```
-
-- **Retry/poll loops on flags**: spinning on a flag waiting for another
-  context to clear it, reimplementing a spinlock without the fairness,
-  deadlock detection, or memory ordering guarantees.
-
-- **Trylock loops to avoid deadlock**: using `mutex_trylock()` or
-  `spin_trylock()` in a loop or repeated invocation to avoid a lock
-  ordering issue is a sign that the locking design is wrong. Trylock is
-  only acceptable in narrow cases — for example, a work item that calls
-  `mutex_trylock()` and on failure reschedules itself (via
-  `schedule_work()` / `schedule_delayed_work()`) so the work runs again
-  later. Open-coded retry loops around trylock, or trylock with fallback
-  to "skip the work entirely", are almost always bugs.
-
-The correct alternatives depend on the access pattern:
-
-- Reader-heavy paths (e.g., `ndo_get_stats64`): use RCU
-- Mutual exclusion with sleep: use a `mutex`
-- Mutual exclusion in atomic context: use a `spinlock_t`
-- Preventing concurrent execution of a timer or work: use
-  `del_timer_sync()` / `cancel_work_sync()`
-
-**REPORT as bugs**: any pattern where a flag, atomic variable, or bit
-operation appears to guard a section of code rather than express state —
-i.e., where the flag is set on entry and cleared on exit of a code region
-to prevent concurrent access, instead of using a proper lock or RCU.
-
 ## Quick Checks
 
 - Validate packet lengths before `skb_put()` / `skb_push()` / `skb_pull()`
 - Call `pskb_may_pull()` before dereferencing protocol headers
 - Check `skb_shared()` / `skb_cloned()` before modifying SKB data
-- Verify `htons()` / `ntohs()` conversions on all port and protocol comparisons
 - Hold `rcu_read_lock()` during routing table lookups and dst access
 - Use BH-safe stat update macros for per-CPU network counters
 - Do not access an SKB after handing it to another subsystem
 - Do not store destructor-needed data in `skb->cb`
-- **Ethtool -S stat duplication**: check whether any new `ethtool -S` counters cover values for which a standard uAPI exists (rtnl_link_stats64, page pool stats, per-queue stats via netlink), regardless of whether the driver currently uses that standard interface
-- **Flags used as locks**: flag/atomic/bit set-on-entry clear-on-exit patterns that guard code sections are ad-hoc locks; use real locks or RCU instead
+- For UAPI structures embedding other structs, verify new fields don't require wider alignment than the embedded struct provides

--- a/kernel/subsystem/networking-drivers.md
+++ b/kernel/subsystem/networking-drivers.md
@@ -1,5 +1,51 @@
 # Networking Drivers: Stats, and Synchronization
 
+## Per-Device Statistics with u64_stats_sync
+
+Driver pre-NAPI/per-queue/per-CPU statistics that count packets and bytes
+use 64-bit counters that can tear on 32-bit architectures (a reader observes
+the low half of one update combined with the high half of the next).
+The `u64_stats_sync` helpers in `include/linux/u64_stats_sync.h` close that
+race using a seqcount on 32-bit and compile to no-ops on 64-bit.
+
+A counter is declared as `u64_stats_t` or pure u64 (paired with one `struct
+u64_stats_sync` per per-CPU container, initialized via `u64_stats_init()`).
+Writers wrap updates in `u64_stats_update_begin()` /
+`u64_stats_update_end()`; readers retry around `u64_stats_fetch_begin()` /
+`u64_stats_fetch_retry()`.
+
+```c
+/* writer (per-CPU, BH-disabled or otherwise serialized) */
+u64_stats_update_begin(&stats->syncp);
+u64_stats_add(&stats->bytes, len);
+u64_stats_inc(&stats->packets);
+u64_stats_update_end(&stats->syncp);
+
+/* reader (e.g., ndo_get_stats64) */
+do {
+    start = u64_stats_fetch_begin(&stats->syncp);
+    bytes = u64_stats_read(&stats->bytes);
+    pkts  = u64_stats_read(&stats->packets);
+} while (u64_stats_fetch_retry(&stats->syncp, start));
+```
+
+Constraints that are easy to get wrong:
+
+- **Writers must be mutually exclusive** for a given `syncp`. Per-CPU
+  or per-NAPI stats satisfy this because each CPU writes its own copy
+  from a non-preemptible context (NAPI, softirq).
+- **Writers must run with preemption disabled.** Per-CPU + BH-disabled (or
+  hardirq) context already provides this. If a writer can be preempted by a
+  reader, the reader spins forever on 32-bit.
+- **Use the `_irqsave` variant when an IRQ handler may also write the same
+  `syncp`, or read it.** `u64_stats_update_begin_irqsave()` /
+  `u64_stats_update_end_irqrestore()` are no-ops with respect to interrupts
+  on 64-bit but disable interrupts on 32-bit.
+- Readers may sleep or be preempted; they perform pure reads.
+- Reader retry loops must be idempotent on retry, common mistake is to
+  use `+=` e.g. `retval->rx_bytes += u64_stats_read(&stats->bytes)`
+  which will add the byte counter multiple times in case on retry.
+
 ## Ethtool Driver Statistics vs Standard Stats
 
 Adding statistics to `ethtool -S` that duplicate counters for which a
@@ -99,5 +145,6 @@ to prevent concurrent access, instead of using a proper lock or RCU.
 
 ## Quick Checks
 
+- **u64_stats_sync writers**: must be mutually exclusive per `syncp` and run with preemption disabled; use the `_irqsave` variant when IRQ context also touches the same `syncp`
 - **Ethtool -S stat duplication**: check whether any new `ethtool -S` counters cover values for which a standard uAPI exists (rtnl_link_stats64, page pool stats, per-queue stats via netlink), regardless of whether the driver currently uses that standard interface
 - **Flags used as locks**: flag/atomic/bit set-on-entry clear-on-exit patterns that guard code sections are ad-hoc locks; use real locks or RCU instead

--- a/kernel/subsystem/networking-drivers.md
+++ b/kernel/subsystem/networking-drivers.md
@@ -1,0 +1,103 @@
+# Networking Drivers: Stats, and Synchronization
+
+## Ethtool Driver Statistics vs Standard Stats
+
+Adding statistics to `ethtool -S` that duplicate counters for which a
+standard kernel uAPI already exists creates confusion, leads to huge
+ethtool -S lists, and adds maintenance burden. Reviewers routinely
+reject such patches.
+
+- **Stats that have a standard uAPI must not be duplicated in `ethtool -S`.**
+  The `ethtool -S` interface (`get_ethtool_stats()` / `get_sset_count()` /
+  `get_strings()`) is for driver-private statistics only — counters that are
+  specific to the hardware or driver and have no standard representation.
+- Standard uAPIs exist for common SW-maintained and standards-defined HW
+  counters. Categories with standard interfaces include:
+  - Network device stats (`struct rtnl_link_stats64` via `ip -s link show`)
+  - Per-queue statistics (via netlink)
+  - Page pool statistics (via netlink, accessible through `ynl` tooling)
+  - Ethtool statistics (for which there is a dedicated callback in
+    `struct ethtool_ops`)
+  - Other counters exposed through standardized netlink attributes
+- A stat does not need to be currently reported by the driver to count as
+  a duplicate — if a standard uAPI exists for that category of counter,
+  the driver must use the standard interface, not `ethtool -S`.
+- When a driver wants to expose a statistic that fits an existing standard
+  category, it should implement the appropriate standard interface (e.g.,
+  `ndo_get_stats64`) rather than adding a private ethtool string.
+- `Documentation/networking/statistics.rst` documents the statistics
+  hierarchy and which interfaces to use.
+
+**REPORT as bugs**: Driver patches that add **new** counters to `ethtool -S`
+for values that have a standard uAPI — whether or not the driver currently
+reports them through that standard interface. Pre-existing `ethtool -S` stats
+that predate the standard uAPI are not bugs in new patches (migrating them is
+a separate cleanup).
+
+## Ad-hoc Synchronization with Flags and Atomics
+
+Driver code that uses atomic variables, bit flags, or boolean fields as
+substitutes for real locks or RCU almost always contains races. These
+homebrew schemes provide no actual synchronization guarantees and are
+invisible to lockdep, so the bugs they introduce go undetected by
+standard kernel debugging tools.
+
+Common broken patterns:
+
+- **Atomic/flag as gate guard**: reading an atomic or flag to decide whether
+  to proceed, then operating on shared data without holding a lock. The
+  flag's value can change immediately after the read, so the "protection"
+  is illusory.
+  ```c
+  // WRONG: intr_sem can change right after the read
+  if (atomic_read(&priv->intr_sem) != 0)
+      return;
+  // ... operates on shared state with no actual lock held
+  ```
+
+- **Bit flags as reader/writer protocol**: using `set_bit()` /
+  `test_bit()` / `clear_bit()` to coordinate access between readers and
+  a teardown path. Multiple concurrent readers can enter, one clears the
+  bit while another is still mid-operation, and the teardown path frees
+  memory that the remaining reader is still accessing.
+  ```c
+  // WRONG: concurrent readers race on the bit
+  set_bit(STATE_READ_STATS, &priv->state);
+  if (!test_bit(STATE_OPEN, &priv->state)) {
+      clear_bit(STATE_READ_STATS, &priv->state);
+      return;
+  }
+  // ... reads from shared data that close path may free
+  clear_bit(STATE_READ_STATS, &priv->state);
+  ```
+
+- **Retry/poll loops on flags**: spinning on a flag waiting for another
+  context to clear it, reimplementing a spinlock without the fairness,
+  deadlock detection, or memory ordering guarantees.
+
+- **Trylock loops to avoid deadlock**: using `mutex_trylock()` or
+  `spin_trylock()` in a loop or repeated invocation to avoid a lock
+  ordering issue is a sign that the locking design is wrong. Trylock is
+  only acceptable in narrow cases — for example, a work item that calls
+  `mutex_trylock()` and on failure reschedules itself (via
+  `schedule_work()` / `schedule_delayed_work()`) so the work runs again
+  later. Open-coded retry loops around trylock, or trylock with fallback
+  to "skip the work entirely", are almost always bugs.
+
+The correct alternatives depend on the access pattern:
+
+- Reader-heavy paths (e.g., `ndo_get_stats64`): use RCU
+- Mutual exclusion with sleep: use a `mutex`
+- Mutual exclusion in atomic context: use a `spinlock_t`
+- Preventing concurrent execution of a timer or work: use
+  `del_timer_sync()` / `cancel_work_sync()`
+
+**REPORT as bugs**: any pattern where a flag, atomic variable, or bit
+operation appears to guard a section of code rather than express state —
+i.e., where the flag is set on entry and cleared on exit of a code region
+to prevent concurrent access, instead of using a proper lock or RCU.
+
+## Quick Checks
+
+- **Ethtool -S stat duplication**: check whether any new `ethtool -S` counters cover values for which a standard uAPI exists (rtnl_link_stats64, page pool stats, per-queue stats via netlink), regardless of whether the driver currently uses that standard interface
+- **Flags used as locks**: flag/atomic/bit set-on-entry clear-on-exit patterns that guard code sections are ad-hoc locks; use real locks or RCU instead

--- a/kernel/subsystem/networking-drivers.md
+++ b/kernel/subsystem/networking-drivers.md
@@ -50,8 +50,7 @@ Constraints that are easy to get wrong:
 
 Adding statistics to `ethtool -S` that duplicate counters for which a
 standard kernel uAPI already exists creates confusion, leads to huge
-ethtool -S lists, and adds maintenance burden. Reviewers routinely
-reject such patches.
+ethtool -S lists, and adds maintenance burden.
 
 - **Stats that have a standard uAPI must not be duplicated in `ethtool -S`.**
   The `ethtool -S` interface (`get_ethtool_stats()` / `get_sset_count()` /
@@ -60,25 +59,23 @@ reject such patches.
 - Standard uAPIs exist for common SW-maintained and standards-defined HW
   counters. Categories with standard interfaces include:
   - Network device stats (`struct rtnl_link_stats64` via `ip -s link show`)
-  - Per-queue statistics (via netlink)
+  - Per-queue statistics (via netlink, struct netdev_queue_stats_rx,
+    struct netdev_queue_stats_tx)
   - Page pool statistics (via netlink, accessible through `ynl` tooling)
   - Ethtool statistics (for which there is a dedicated callback in
     `struct ethtool_ops`)
   - Other counters exposed through standardized netlink attributes
-- A stat does not need to be currently reported by the driver to count as
-  a duplicate — if a standard uAPI exists for that category of counter,
-  the driver must use the standard interface, not `ethtool -S`.
 - When a driver wants to expose a statistic that fits an existing standard
-  category, it should implement the appropriate standard interface (e.g.,
-  `ndo_get_stats64`) rather than adding a private ethtool string.
+  category, it should implement the appropriate standard interface
+  rather than adding a private ethtool string.
 - `Documentation/networking/statistics.rst` documents the statistics
   hierarchy and which interfaces to use.
 
-**REPORT as bugs**: Driver patches that add **new** counters to `ethtool -S`
-for values that have a standard uAPI — whether or not the driver currently
-reports them through that standard interface. Pre-existing `ethtool -S` stats
-that predate the standard uAPI are not bugs in new patches (migrating them is
-a separate cleanup).
+**REPORT as bugs**: Driver patches that add strings to `ethtool -S`
+for counters that have a standard uAPI. You must find at least one statistic
+being added to the driver for which standard interface exists before reporting.
+Pre-existing `ethtool -S` stats that predate the standard uAPI are not bugs
+in new patches (migrating them is a separate cleanup).
 
 ## Ad-hoc Synchronization with Flags and Atomics
 

--- a/kernel/subsystem/networking.md
+++ b/kernel/subsystem/networking.md
@@ -107,22 +107,6 @@ Once an SKB is passed to another subsystem (queued, enqueued, handed to a
 protocol handler), the caller loses ownership. The receiver may free it at
 any time, including before the handoff function returns.
 
-## Byte Order Conversions
-
-Byte order mismatches cause silent data corruption -- packets are
-misrouted, ports are mismatched, and protocol fields are misinterpreted.
-
-Network protocols use big-endian byte order. The kernel uses `__be16`,
-`__be32`, and `__be64` types (defined in `include/uapi/linux/types.h`)
-to annotate network-order values. Common byte order bugs:
-
-- Comparing a `__be16` port with a host-order constant without `htons()`
-- Performing arithmetic on network-order values without converting first
-- Double-converting (applying `htons()` to an already network-order value)
-
-Sparse catches these at build time via `__bitwise` type annotations
-(active when `__CHECKER__` is defined; run with `make C=1`).
-
 ## RCU Protection for Routing
 
 Accessing a dst entry outside its RCU read-side critical section causes

--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -19,6 +19,7 @@ regexes
 | Subsystem | Triggers | File |
 |-----------|----------|------|
 | Networking | net/, drivers/net/, skb_, sockets | networking.md |
+| Netlink | `genl_`, `nla_`, `NLA_`, `NLM_F_`, `nlmsg_`, `netlink_callback`, Documentation/netlink/specs/, files marked `YNL-GEN` | netlink.md |
 | MM Page Tables | `pte_*`, `pmd_*`, `pud_*`, `set_pte`, `ptep_*`, `tlb_*`, `page_vma_mapped_walk`, `walk_page_range`, `zap_pte_range`, mm/memory.c, mm/mprotect.c, mm/pagewalk.c | mm-pagetable.md |
 | MM Folio/Page Cache | `folio_*`, `page_folio`, `compound_head`, `filemap_*`, `xa_*`, `xas_*`, `page_cache_*`, mm/filemap.c, mm/swap.c, mm/truncate.c | mm-folio.md |
 | MM Large Folios/THP/Hugetlb | `huge_memory`, `hugetlb`, `split_huge_*`, `folio_test_large`, `hstate`, PMD sharing, mm/huge_memory.c, mm/hugetlb.c, mm/memory-failure.c | mm-largepage.md |

--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -13,12 +13,13 @@ regexes
 > **Path resolution:** every filename in the "File" column below — and in the
 > "Optional Patterns" section — is relative to **this file's directory**:
 > `review-prompts/kernel/subsystem/`. For example,
-> `networking.md` resolves to
-> `review-prompts/kernel/subsystem/networking.md`.
+> `networking-core.md` resolves to
+> `review-prompts/kernel/subsystem/networking-core.md`.
 
 | Subsystem | Triggers | File |
 |-----------|----------|------|
-| Networking | net/, drivers/net/, skb_, sockets | networking.md |
+| Networking Core | net/, skb_, sockets, xfrm, dst_, sock_put, release_sock, pskb_may_pull, SNMP_*_STATS | networking-core.md |
+| Networking Drivers | drivers/net/, ethtool_ops, net_device_ops | networking-drivers.md |
 | Netlink | `genl_`, `nla_`, `NLA_`, `NLM_F_`, `nlmsg_`, `netlink_callback`, Documentation/netlink/specs/, files marked `YNL-GEN` | netlink.md |
 | MM Page Tables | `pte_*`, `pmd_*`, `pud_*`, `set_pte`, `ptep_*`, `tlb_*`, `page_vma_mapped_walk`, `walk_page_range`, `zap_pte_range`, mm/memory.c, mm/mprotect.c, mm/pagewalk.c | mm-pagetable.md |
 | MM Folio/Page Cache | `folio_*`, `page_folio`, `compound_head`, `filemap_*`, `xa_*`, `xas_*`, `page_cache_*`, mm/filemap.c, mm/swap.c, mm/truncate.c | mm-folio.md |


### PR DESCRIPTION
Add a guide for Netlink. 
Split networking core from drivers, mostly because I feel awkward adding very driver-specific guidance to the common doc.