### PR TITLE
kernel: quote commit-message review anchors

### DIFF
--- a/kernel/agent/report.md
+++ b/kernel/agent/report.md
@@ -233,6 +233,10 @@ than asserting a definite bug.
 The decisions about filtering issues happened in other prompts, your one and
 only job is to format those issues.
 
+**Commit-message issues**: Treat any issue with `file_name: "COMMIT_MESSAGE"`
+or an issue source that points at the commit message as a commit-message issue,
+and format it using inline-template.md's "Commit Message Issues" section.
+
 Follow inline-template.md's instructions to create `<output_dir>/review-inline.txt` using the issue data from the result files
 
 ### Step 5: Create review-metadata.json

--- a/kernel/inline-template.md
+++ b/kernel/inline-template.md
@@ -164,6 +164,36 @@ or areas where the author clearly just missed updating some code.   If you
 expect a reasonable maintainer to understand a short explanation, use
 a short explanation.
 
+## Commit Message Issues
+
+For issues in the commit message, quote the entire commit message as the first
+quoted block.  This matches normal mailing list replies, and avoids making the
+review question appear before the text it is reviewing.  Put the question after
+that quoted block.
+
+For a missing Fixes: tag, quote the full commit message:
+
+```
+commit 533c6d48ce4a00a5deb5eea6c921b5d019838b5e
+Author: Yonghong Song <yonghong.song@linux.dev>
+
+>     bpf: Add precision marking and backtracking for stack argument slots
+>
+>     Extend the precision marking and backtracking infrastructure to
+>     support stack argument slots (r11-based accesses). Without this,
+>     precision demands for scalar values passed through stack arguments
+>     are silently dropped, which could allow the verifier to incorrectly
+>     prune states with different constant values in stack arg slots.
+>
+>     Signed-off-by: Yonghong Song <yonghong.song@linux.dev>
+
+This looks like a bug fix for stack argument support.  Should this include:
+
+  Fixes: 3330ee8db989 ("bpf: Support stack arguments for bpf functions")
+```
+
+Do not write the question before the first quoted commit message or diff block.
+
 ## NEVER QUOTE LINE NUMBERS
 
 - Never mention line numbers when referencing code locations, instead indicate


### PR DESCRIPTION
Teach the report aggregator to treat COMMIT_MESSAGE findings as commit-message issues, then format them through the inline template instead of anchoring them on the diff. Add an example for missing Fixes: trailers so the generated review quotes the relevant commit-message text before asking whether the trailer should be added.