### PR TITLE
  kernel: add KVM and ARM64 subsystem guides

### DIFF
--- a/kernel/review-core.md
+++ b/kernel/review-core.md
@@ -103,7 +103,7 @@ IMMEDIATELY.
      find it unless you search the parent commit.
 
 2. **Without semcode (fallback)**:
-   - Use git diff to identify changes
+   - Use `git show <sha>` to identify changes. Do not use `git diff` against HEAD: `review_one.sh` checks out a worktree with the commit applied, so `git diff` will be empty.
    - Manually find function definitions and relationships with grep and other tools
    - Document any missing context that affects research quality
 

--- a/kernel/subsystem/arm64.md
+++ b/kernel/subsystem/arm64.md
@@ -1,0 +1,251 @@
+# ARM64 Subsystem Details
+
+This guide covers architectural invariants, memory ordering rules, and common
+bug patterns for the ARM64 (AArch64) architecture, derived from historical
+lore and the ARM Architecture Reference Manual (ARM ARM).
+
+## Memory Tagging Extension (MTE) and Tagged Addresses
+
+Mishandling MTE tags or tagged addresses causes `KASAN invalid-access` panics,
+spurious tag check faults, and memory permission corruption.
+
+- **Pointer Arithmetic:** The Top Byte Ignore (TBI) hardware feature allows
+  the MMU to ignore bits [63:56] during address translation. However,
+  **software-side arithmetic** (e.g., bit-shifts to compute page indices) MUST
+  explicitly untag the address (e.g., via `untagged_addr()`) to prevent tag
+  bits from corrupting calculation results.
+    - **Note:** If `FEAT_PAuth` is implemented, `TCR_ELx.TBIDn` selects
+      whether TBI applies to instruction fetches as well as data; otherwise
+      TBI applies to both unconditionally.
+- **Tag Initialization Barriers:** A DSB between tag stores (`STG`/`STZG`) and
+  the PTE update is required so the explicit tag stores complete before the
+  table walker's implicit TTD reads observe the mapping.
+- **Shared Page Tag Initialization:** Marking a shared or special page (e.g.,
+  the **Linux-specific** huge zero folio) as MTE-tagged too early during
+  initialization causes userspace to map the page before its tags are
+  definitively cleared. Tag clearing MUST be synchronized and visible before
+  the page is made accessible to other observers.
+
+**REPORT as bugs:**
+- Using a virtual address directly in a bit-shift or mask operation to find a
+  page-table entry without calling `untagged_addr()`.
+- Updating a PTE for an MTE-enabled page without a preceding `DSB` after the
+  tags were written to ensure visibility to the walker.
+
+## System Register and Context Synchronization
+
+Updates to architectural configuration system registers (e.g., `GCR_EL1`,
+`SCTLR_EL1`, `TCR_EL1`) are not guaranteed to be visible to subsequent
+instructions without an explicit Context Synchronization Event (CSE).
+
+Missing synchronization results in unpredictable behavior where the CPU
+operates under a stale configuration for several cycles, breaking memory
+safety semantics or causing unexpected traps.
+
+- **Context Synchronization Events (CSE):** A CSE ensures preceding state
+  changes are resolved. Events that constitute a CSE include:
+    - Executing an `isb` instruction.
+    - Exception entry or return (subject to `SCTLR_ELx.{EIS, EOS}` bits and
+      `FEAT_ExS`).
+- **Immediate Synchronization:** Every write to a control-plane system
+  register MUST be followed by an `isb()` *as the very next instruction*. The
+  barrier must precede any subsequent read-back, comparison, conditional
+  branch, return, or further sysreg access — not just appear "somewhere later"
+  in the function. Code that places *any* instruction between the write and
+  the `isb()` is buggy, even when an `isb()` is eventually issued, because the
+  intervening instruction observes architecturally undefined pipeline state.
+- **GIC Synchronization:**
+    - Writes to most `ICC_*_EL1` registers require a CSE to be visible to
+      subsequent instructions. Notable exceptions: writes to `ICC_PMR_EL1` and
+      reads of `ICC_IAR{0,1}_EL1` / `ICC_NMIAR1_EL1` (when `PSTATE.{I,F} ==
+      {0,0}`) are self-synchronizing.
+    - Writes to specific memory-mapped GIC registers require polling the RWP
+      bit. `GICD_CTLR.RWP` tracks group-enable disables (1→0), `GICD_CTLR`
+      ARE/DS field writes, and `GICD_ICENABLER<n>`. `GICR_CTLR.RWP` tracks
+      `GICR_ICENABLER0`, `GICR_CTLR.EnableLPIs` (1→0), and DPG writes.
+      Priority, routing, and enable-set writes are NOT tracked by either RWP
+      bit.
+
+**REPORT as bugs:**
+- Writing to a control system register without an `isb()` as the very next
+  instruction. Includes patterns that delay the barrier behind a
+  read-back-and-verify, a conditional branch, or any other instruction. Worked
+  example of the bug:
+    ```c
+    write_sysreg_s(val, SYS_HFGRTR_EL2);
+    if (read_sysreg_s(SYS_HFGRTR_EL2) != val)   /* observes pipeline */
+        return -EIO;
+    isb();                                       /* too late — read-back already executed */
+    ```
+  The `isb()` exists, but the read-back has already executed against
+  architecturally undefined pipeline state. Correct ordering is `write → isb()
+  → read-back`.
+- Writing to `ICC_*_EL1` registers (excluding `ICC_PMR_EL1`) without an
+  `isb()`.
+- Writing to tracked memory-mapped GIC registers without polling the
+  appropriate `GICD_CTLR.RWP` or `GICR_CTLR.RWP`.
+
+## TLB Invalidation and Break-Before-Make (BBM)
+
+Failure to follow the correct invalidation and synchronization sequence leads
+to pipeline inconsistencies, stale TLB usage, and TLB Conflict Aborts.
+
+### TLB Maintenance Observer Rules
+
+The completion of a TLB maintenance instruction (`TLBI`) is guaranteed
+**only** by the execution of a `DSB` by the **same** Processing Element (PE)
+that performed the `TLBI`.
+
+- **Global Visibility:** A broadcast `TLBI` (e.g., `TLBI VAE1IS`) is only
+  guaranteed to be finished for all other PEs after the issuing PE executes a
+  `DSB ISH`.
+- **Remote DSB Inefficacy:** CPU B cannot use its own `DSB` to force CPU A's
+  broadcasted `TLBI` to complete.
+- **Local Synchronization:** `isb` instructions are NOT broadcast. Each
+  observing PE MUST independently execute its own `isb()` (or undergo a CSE)
+  locally *after* the issuing PE's `DSB` completes to ensure the invalidation
+  is visible to the local fetch path.
+
+### Break-Before-Make (BBM) Requirements
+
+When updating a live translation table entry (shared across multiple threads),
+you MUST follow the BBM sequence to prevent TLB conflicts.
+
+**BBM is strictly required when:**
+- **Changing block or table sizes:** `FEAT_BBML1/2` relax the requirement for
+  an explicitly-invalid intermediate descriptor; TLB maintenance is still
+  required.
+- **Creating a global entry** that overlaps existing non-global entries.
+- **Changing the Output Address (OA):** Strictly required by the architecture
+  if the contents of memory at the new OA do not match the contents at the
+  previous OA.
+- **Changing memory attributes** (type or cacheability).
+
+**The BBM Sequence:**
+1. Replace the old entry with an invalid entry.
+2. Execute a `DSB` (ensure invalid entry is globally visible).
+3. Invalidate relevant TLB entries (Broadcast `TLBI`).
+4. Execute another `DSB` (ensure invalidation is complete).
+5. Write the new, updated translation table entry.
+6. Execute a final `DSB`.
+
+**REPORT as bugs:**
+- Code performing `TLBI` without both a subsequent `DSB` and `isb()` on the
+  issuing CPU (for executable mappings or where local synchronization is
+  required).
+- Missing `isb()` after TLBI in mode-entry paths (e.g., `enter_vhe()`, nVHE
+  `__tlb_switch_to_guest()`, `__primary_switch()`); the TLBI is not
+  synchronized to the new execution context without it.
+- Updating a live page table entry (changing OA to a non-matching address or
+  attributes) without an intervening invalidation (skipping the "Break" step).
+- Kernel block/page-mapping changes on systems where secondary CPUs may not
+  support `FEAT_BBML2`, without gating on the CPU-feature cap or falling back
+  to full BBM.
+
+## Instruction and Data Coherency (PoC vs PoU)
+
+The architecture does not inherently ensure coherency between instruction
+caches and memory. Software must manage this manually using the Point of
+Unification (PoU) or Point of Coherency (PoC).
+
+- **Self-Modifying Code (PoU):** When writing new instructions as data (e.g.,
+  JIT), software MUST:
+    1. Clean the data cache to the PoU (`DC CVAU`).
+    2. Execute `DSB ISH`.
+    3. Invalidate the instruction cache to the PoU (`IC IVAU`).
+    4. Execute `DSB ISH`.
+    5. Ensure an `isb()` occurs on **all observing CPUs** (e.g., via IPI).
+- **Instruction Patching (CMODX):** Concurrent modification and execution of
+  instructions is safe only for the architecturally enumerated CMODX set: `B`,
+  `B.cond`, `BL`, `BRK`, `CB<cc>`, `CBB<cc>`, `CBH<cc>`, `CBNZ`, `CBZ`, `HVC`,
+  `ISB`, `NOP`, `SMC`, `SVC`, `TBNZ`, `TBZ`, `TRCIT`, and `UDF`. For all other
+  instructions, an explicit `isb()` or CSE is mandatory on **all observing
+  CPUs** before execution.
+- **External Agents (PoC):** Communicating with non-coherent DMA controllers
+  or managing mismatched memory attributes requires cleaning/invalidating to
+  the Point of Coherency (PoC) (e.g., `DC CVAC`).
+
+**REPORT as bugs:**
+- Modifying instructions (e.g., jump label patching) without ensuring an
+  `isb()` or CSE occurs on all CPUs executing the modified code.
+
+## Lockless Page Table Walks
+
+Lockless walkers (e.g., GUP or fast-path page faults) must carefully manage
+compiler ordering to avoid observing inconsistent page table states.
+
+- **Atomicity and Ordering:** Software MUST use `READ_ONCE()` when loading a
+  descriptor from a shared page table in a lockless walk to prevent the
+  compiler from splitting the load or reordering it against subsequent logic.
+- **Folded Level Handling:** When some page-table levels are statically folded
+  (`PGTABLE_LEVELS ≤ 2`), lockless walks must account for the folded topology.
+  The standard multi-level `READ_ONCE()` pattern applied at a folded level
+  will observe stale or incorrect state.
+
+**REPORT as bugs:**
+- Dereferencing a shared PTE/PMD/PUD/PGD pointer in a lockless walk without
+  using `READ_ONCE()`.
+- Lockless walk logic that assumes all page-table levels are live without
+  checking for folded-level conditions.
+
+## Exception Handling and Stack Management
+
+Manipulating the Stack Pointer (`SP`) is architecturally hazardous due to
+potential clobbering of exception return state (`ELR_ELx`, `SPSR_ELx`).
+
+- **DAIF Masking:** Asynchronous exceptions (IRQ, FIQ, SError) MUST be masked
+  during stack transitions or pivots (e.g., when switching to a
+  **Linux-specific** Shadow Call Stack). An exception hitting while `SP` is
+  being moved or state is out of sync will cause fatal recursive faults.
+- **Stack Alignment:** `SCTLR_ELx.SA` enforces 16-byte SP alignment for memory
+  accesses at ELx; `SCTLR_EL1.SA0` controls the same check at EL0. Check is on
+  memory access via SP, not on SP modification.
+
+**REPORT as bugs:**
+- Manipulating `SP` or switching stacks without masking `DAIF`.
+
+## SVE, SME, and FPSIMD Register State
+
+Vector-length changes and signal-return paths have a history of leaving stale
+register state or performing incorrect state merges.
+
+- **VL-Change State Invalidation:** When the SVE or SME vector length is
+  changed for a task, any context derived from the old VL (buffers, register
+  views, ptrace payloads) MUST be invalidated or rebuilt before execution
+  continues. Incomplete invalidation resurrects stale data in the new
+  vector-width context.
+- **Streaming-Mode SVE Payload:** When entering streaming SVE mode, the
+  ptrace/signal interface requires an explicit SVE payload for streaming-mode
+  state; inheriting previous non-streaming state is architecturally incorrect.
+- **FPSIMD/SVE State Merge on Signal Return:** When returning from a signal
+  handler, FPSIMD and SVE state must be merged in a single coherent step.
+  Partial or incorrectly ordered merges silently corrupt the Z-register upper
+  halves.
+
+**REPORT as bugs:**
+- VL-change paths that do not invalidate or rebuild SVE/SME register context
+  for the new length.
+- Signal-return paths that merge FPSIMD and SVE register state incorrectly or
+  in multiple non-atomic steps.
+
+## Quick Checks
+
+- **System Instructions with Fixed Register Requirements:** Inline assembly
+  for system instructions that demand specific registers (e.g., `GIC CDEOI`
+  requiring `XZR` / register 31) MUST hardcode the exact register in the
+  instruction string. Relying solely on compiler constraints (like `r`) can
+  lead to misencoded instructions if the compiler selects a general-purpose
+  register, causing `CONSTRAINED UNPREDICTABLE` behavior.
+- **CONSTRAINED UNPREDICTABLE:** Triggered by invalid encodings or register
+  overlaps. Hardware may execute as a `NOP`, treat as `UNDEFINED`, or generate
+  `Alignment/MMU faults`. It results in **UNKNOWN** state and MUST NOT be
+  relied upon.
+- **TLBI Range Operands:** Range-based invalidation (e.g., `TLBI RVAE1IS`)
+  requires correct `SCALE` and `NUM` encoding. If `TG` does not match the
+  current granule, the TLBI is CONSTRAINED UNPREDICTABLE — possibly including
+  no invalidation.
+- **PTE Barrier Batching:** Batching DSB/ISB across multiple kernel-mapping
+  PTE updates is only correct in contexts that cannot be interrupted
+  mid-batch. In interrupt contexts the batching window is broken and an
+  explicit barrier must be issued before the interrupted path observes the
+  mappings.

--- a/kernel/subsystem/hyp-arm64.md
+++ b/kernel/subsystem/hyp-arm64.md
@@ -1,0 +1,482 @@
+# ARM64 Hyp (EL2) Subsystem Details
+
+This guide covers the ARM64 Hypervisor implementation running at EL2, focusing
+on pKVM (Protected KVM) and nVHE isolation, derived from historical fixes and
+the ARM Architecture Reference Manual (ARM ARM).
+
+## pKVM Threat Model and Scope
+
+pKVM at EL2 provides a fixed set of guarantees against a hierarchy of
+adversaries. Reviews must scope findings against this model: violations inside
+the model are bugs; behavior that is undesirable but outside the model (e.g.
+host self-DoS) is a hardening improvement, not a bug.
+
+### What pKVM guarantees
+
+*   **Guest confidentiality** vs. Host: Host EL1 cannot read protected-VM
+    memory or register state.
+*   **Guest integrity** vs. Host: Host EL1 cannot modify protected-VM memory
+    or register state out-of-band.
+*   **Hypervisor integrity** vs. Host AND Guests: neither side can corrupt EL2
+    memory, redirect EL2 control flow, or escape stage-2 isolation.
+*   **Host availability** vs. Guests: a guest cannot crash the host kernel or
+    take down EL2 (taking EL2 down takes the host down with it).
+
+### What pKVM does NOT guarantee
+
+*   **Host availability vs. itself**: the host kernel can panic itself, or
+    trigger a hyp panic via the hypercall ABI from its own privileged code
+    paths. pKVM does not defend the host against the host.
+*   **Reliability against firmware/hardware faults**: if EL3, the SMMU, the
+    GIC, or other firmware/hardware misbehaves, pKVM cannot recover.
+
+### Reachability test for any panic-reachable EL2 path
+
+For any code that can reach a fatal primitive at EL2 (`BUG`, `BUG_ON`,
+`WARN_ON`, direct `hyp_panic()`), ask: **who can trigger it?**
+
+| Trigger source | Verdict |
+|---|---|
+| EL2 internal invariant violation | Bug in EL2 itself, separate from the panic |
+| Hardware / firmware error | Out of scope (trust boundary) |
+| Host kernel, via privileged code paths | Not a bug. Hardening improvement if cheap |
+| Guest, via DMA / hypercall side-effects / shared memory | **Bug** (violates host availability vs. guests) |
+| Host userspace, via syscall/ioctl → host kernel → hypercall | **Bug** (violates the Linux kernel security model: userspace must not crash the kernel) |
+
+The host-userspace row matters because many hypercalls are reachable from
+userspace through the host's syscall surface; a hyp panic on
+userspace-influenced inputs breaks Linux's standard "userspace must not crash
+the kernel" property even if the immediate caller at EL1 is the host kernel.
+
+This test composes with the §`WARN_ON` Semantics correctness test, but does
+not replace it. Correctness ("is this assertion the right kind of check?") and
+severity ("if it triggers, is it a bug?") are independent axes.
+
+## Host De-Privilege Boundary (pKVM Lifecycle)
+
+In nVHE/pKVM, the host kernel boots at EL2 and *de-privileges itself* to EL1
+once hyp setup is complete. This boundary is the most important architectural
+state for reviewing pKVM patches: the same code can run in a fundamentally
+different trust regime depending on which side of it executes.
+
+The boundary is `finalize_pkvm()` (`arch/arm64/kvm/pkvm.c`), registered at
+`device_initcall_sync`. It calls `pkvm_drop_host_privileges()`, which switches
+the host out of EL2 for good. Before this initcall level, the host kernel is
+still executing at EL2 — code is privileged and can directly set up EL2 state,
+install hyp text/data, populate per-CPU state, and finalize trap
+configuration; memory shared with future-EL2 is writable in place. After it
+(`pkvm_drop_host_privileges()` having run), the host is at EL1 and can only
+invoke EL2 via hypercalls; EL2-private memory becomes inaccessible (kmemleak
+excluded above).
+
+**Markers a reviewer can grep for:**
+
+*   `__init` / `__initdata` on hyp-touching code: pre-de-privilege only.
+*   **Initcall level** is the canonical pre-vs-post marker. `finalize_pkvm()`
+    is registered at `device_initcall_sync`. Functions registered at any level
+    strictly before that (`early_initcall`, `pure_initcall`, `core_initcall`,
+    `postcore_initcall`, `arch_initcall`, `subsys_initcall`, `fs_initcall`,
+    `rootfs_initcall`, `device_initcall`, and the `_sync` variants of those)
+    run before `finalize_pkvm` and are pre-de-privilege. `late_initcall` and
+    later levels run post-de-privilege. `module_init(fn)` expands to
+    `device_initcall(fn)`. Code reachable from `kvm_arm_init`
+    (`device_initcall`, including `init_hyp_mode`, `init_subsystems`,
+    `finalize_init_hyp_mode`) is therefore pre-de-privilege.
+*   `__pkvm_init` and **`__pkvm_init_finalise`**
+    (`arch/arm64/kvm/hyp/nvhe/setup.c`) execute *during* de-privilege itself,
+    after `kvm_arm_init` and just before the host drops out of EL2. These are
+    the last opportunity to set up EL2-private state from privileged context.
+*   `is_kvm_arm_initialised()` (`arch/arm64/include/asm/virt.h`) is the
+    canonical predicate for "KVM-arm init has completed" (post-de-privilege).
+    A guard of the form `if (... || is_kvm_arm_initialised()) return -EINVAL;`
+    rejects the call *after* init, so the call is permitted only in the
+    privileged window.
+*   `is_protected_kvm_enabled()` (`arch/arm64/include/asm/virt.h`) is the
+    canonical predicate for "pKVM mode is configured." It becomes true very
+    early via cpufeature detection (before any initcall runs) and is
+    independent of de-privilege state. The privileged window is characterized
+    by `is_protected_kvm_enabled() && !is_kvm_arm_initialised()`.
+
+**REPORT as bugs:**
+
+*   Code that handles host-shared memory without identifying which side of
+    de-privilege it runs on (the §EL2 Security & Trust Boundary rules apply
+    post-de-privilege only).
+*   Patches that move setup code across the `finalize_pkvm` boundary without
+    updating the trust assumptions of the moved code (host-trusted in-place
+    writes pre-de-priv become host-untrusted post-de-priv).
+*   Runtime hypercall handlers that reference `__init` / `__initdata` symbols
+    (those are freed/inaccessible after de-privilege; in particular,
+    `kmemleak_free_part` is called on hyp `.bss` / `.data` / `.rodata` in
+    `finalize_pkvm`).
+
+## EL2 Security & Trust Boundary (pKVM)
+
+Post-de-privilege (after `finalize_pkvm`), the Host (EL1) is an adversary
+against guest confidentiality, guest integrity, and hypervisor integrity (see
+§pKVM Threat Model and Scope). EL2 MUST NOT derive security-sensitive values
+from any host-controlled source.
+
+> Failure to validate Host-provided data leads to **Hypervisor-level Memory
+> Corruption** or **Information Leaks**. Severity classification (bug vs.
+> hardening improvement) follows §pKVM Threat Model and Scope: host
+> availability against the host itself is not in scope, but compromise of
+> confidentiality, integrity, or guest-reachable availability is.
+
+*   **Untrusted Host Data Sources:**
+    *   **Host Memory** (`kern_hyp_va` dereferences): Subject to **TOCTOU**
+        (Time-of-Check to Time-of-Use) attacks. Data MUST be copied to private
+        EL2 memory (e.g., local stack via struct assignment or `memcpy`)
+        BEFORE validating or acting on it.
+    *   **System Registers** carrying host-written state (e.g., `SCTLR_EL1`,
+        `HCR_EL2`): EL2 MUST use **hardcoded architectural constants** or
+        known-good EL2-private state instead of reading back what the host
+        last wrote.
+    *   **Hypercall Arguments**: Every host-supplied value MUST be validated
+        and bounds-checked before use. Never act on raw hypercall parameters.
+        Scalars passed in registers (e.g., `u64`, handles, indices captured
+        via `DECLARE_REG`) become EL2-private once held in a local variable;
+        the copy-then-validate rule applies to host-memory pointers
+        dereferenced via `kern_hyp_va`, not to register-passed values.
+*   **Double-Fetch Risk:** Never dereference a host-provided pointer multiple
+    times (double-fetch). Copy the necessary fields to EL2 private memory
+    once.
+*   **VA Translation (`AT`):** To perform stage 1+2 translation of a Host VA,
+    EL2 must use `AT S12E1R`. If translation fails, hardware reports the error
+    in `PAR_EL1` (bit `.F = 1`).
+    - **Note:** The targeted translation regime (EL1&0 vs EL2&0) depends on
+      `HCR_EL2.{E2H, TGE}`.
+
+**REPORT as bugs:**
+*   Dereferencing a Host pointer multiple times without an intervening copy to
+    private EL2 memory.
+*   Logic that assumes a value in a Host-shared structure (like `struct
+    kvm_vcpu`) remains constant between a check and a subsequent use.
+*   Code that reads security-sensitive state (like trap configurations) from
+    registers known to be modifiable by the Host.
+
+```c
+// WRONG: Double-fetching host-shared memory OR stack overflow risk
+void handle_hcall(struct kvm_vcpu *host_vcpu) {
+    // 1. Double fetch from host memory!
+    if (vcpu_has_sve(kern_hyp_va(host_vcpu))) {
+        do_sve(kern_hyp_va(host_vcpu));
+    }
+    // 2. Unsafe stack allocation (~4KB overflow)
+    struct kvm_vcpu local_vcpu = *kern_hyp_va(host_vcpu); 
+}
+
+// CORRECT: Atomic Copy-then-Validate (Small Struct)
+void handle_hcall(struct vcpu_reset_args *host_args) {
+    struct vcpu_reset_args local_args;
+    
+    // Copy once to private memory to prevent TOCTOU
+    memcpy(&local_args, kern_hyp_va(host_args), sizeof(local_args));
+    
+    // Validate and act on the PRIVATE copy only
+    if (local_args.flags & VALID_FLAG) {
+        update_hyp_state(&local_args);
+    }
+}
+```
+
+## pKVM/nVHE Invariants (EL2)
+
+Violating hypervisor invariants results in **Hypervisor Panics**, **Silent
+Isolation Breaks**, or **Memory Protection Bypass**.
+
+### Security Metadata Initialization (pKVM)
+Security-critical metadata tracking physical resources (e.g., page ownership
+tables like `hyp_vmemmap` in `arch/arm64/kvm/hyp/include/nvhe/memory.h`) MUST
+use initialization patterns that evaluate to the least-privileged or "unowned"
+state. This ensures that accidental access to zero-filled or uninitialized
+memory does not result in unauthorized ownership or permission grants. In
+pKVM, this is achieved via a complement-based state where zero-initialization
+evaluates to `PKVM_NOPAGE`.
+> **REPORT as bugs:** Code that checks page state by direct comparison with
+> zero or assumes zero-filled metadata means "owned by hypervisor."
+
+### Stage-2 VMID & Consistency
+The architecture does not require `VTTBR_EL2` and `VTCR_EL2` (see
+`arch/arm64/include/asm/kvm_mmu.h`) to be identical across all PEs for a VMID,
+**provided** `VTTBR_EL2.CnP == 0`.
+> **REPORT as bugs:** Setting `VTTBR_EL2.CnP = 1` (Common not Private) on
+> multiple PEs if their translation table pointers differ for the same VMID.
+> This results in **CONSTRAINED UNPREDICTABLE** translations.
+
+### Fine-Grained Traps (FEAT_FGT)
+Accesses to FGT registers (e.g., `HFGRTR_EL2`) may be reordered. To guarantee
+a newly enabled trap is active for subsequent instructions, a **Context
+Synchronization Event (CSE)** (e.g., `isb` or exception return) MUST occur.
+
+### SMC Trapping
+For AArch64 guests, `SMC` instructions trapped from EL1 via `HCR_EL2.TSC = 1`
+result in `ESR_EL2.EC = 0x17`; for AArch32 guests, `SMC32` uses `EC = 0x13`.
+`SPSR_EL2.SS` captures the `PSTATE.SS` (Software Step) bit of the trapped EL1
+context.
+
+## State Divergence & Initialization Boundaries
+
+pKVM state is physically isolated from the Host. Assuming Host state changes
+are visible to EL2 leads to **State Desynchronization**.
+
+| Host State | EL2 Hyp State | Sync Mechanism | Source Reference |
+| :--- | :--- | :--- | :--- |
+| `struct kvm` | `struct pkvm_hyp_vm` | `pkvm_create_hyp_vm()` | `arch/arm64/kvm/hyp/nvhe/pkvm.c` |
+| `struct kvm_vcpu` | `struct pkvm_hyp_vcpu` | Hypercall Parameters | `arch/arm64/kvm/hyp/nvhe/hyp-main.c` |
+| ID Registers | Hyp-Private ID Regs | Sanitisation in `pkvm_hyp_vm` | `arch/arm64/kvm/hyp/nvhe/sys_regs.c` |
+
+*   **Hyp vs. Host Back-Pointer:** `struct pkvm_hyp_vm` *embeds* a `struct kvm
+    kvm` — the EL2-private hyp copy — and separately holds `struct kvm
+    *host_kvm`, a back-pointer to the host's (untrusted) instance. Fields
+    accessed via `hyp_vm->kvm.X` are EL2-private and safe to treat as trusted
+    after initialisation; fields reached via `hyp_vm->host_kvm->X` are
+    host-writable and subject to TOCTOU. The same distinction applies to
+    `pkvm_hyp_vcpu` (`hyp_vcpu->vcpu` is EL2-private; `hyp_vcpu->host_vcpu` is
+    the untrusted back-pointer).
+*   **Persistent State Rule:** Copies from Host memory to the stack are for
+    **validation only**. Persistent guest state changes MUST be synchronized
+    to EL2-private hyp structures (e.g., `pkvm_hyp_vcpu`) to remain visible
+    across guest entries.
+
+## EL2 Buddy Allocator (`hyp_pool`)
+
+EL2 uses a private buddy allocator (`struct hyp_pool` in
+`arch/arm64/kvm/hyp/include/nvhe/gfp.h`, implementation in
+`nvhe/page_alloc.c`). It is the *only* page allocator available at EL2 — there
+is no `kmalloc`, no `alloc_pages`. There is one global pool (`hpool`, set up
+in `__pkvm_init_finalise`) plus one per protected VM (`hyp_vm->pool`).
+
+**API** (all symbols are EL2-only; do not confuse with the host page
+allocator):
+
+*   `hyp_alloc_pages(pool, order)` — returns a refcount=1 page; NULL on OOM.
+    Pages are zeroed.
+*   `hyp_get_page(pool, addr)` — increments refcount.
+*   `hyp_put_page(pool, addr)` — decrements; on last ref the page is **zeroed
+    and reattached to the buddy tree**. (Zeroing happens on free, not on
+    alloc.)
+*   `hyp_split_page(page)` — break a high-order block into
+    individually-refcounted order-0 pages; each must be put separately.
+*   `hyp_pool_init(pool, pfn, nr_pages, reserved_pages)` — `reserved_pages`
+    are kept at refcount 1 and never enter the free tree.
+*   `hyp_page_count(addr)` — returns the current refcount of the page.
+
+**Invariants:**
+
+*   **Lock discipline:** `pool->lock` protects *both* the buddy tree *and*
+    per-page metadata (`struct hyp_page::refcount`, `::order`). Refcount
+    changes that may trigger a tree update (`hyp_put_page`) MUST happen inside
+    the same critical section as the tree update. Do not read or mutate
+    `page->refcount` / `page->order` outside `pool->lock` and assume
+    consistency.
+*   **`HYP_NO_ORDER` convention:** for a high-order block, only the head
+    `struct hyp_page` carries its order; the tail `struct hyp_page`s carry
+    `HYP_NO_ORDER`. Walkers that inspect `->order` must handle this.
+*   **Cross-pool:** every `hyp_put_page` must use the same pool the page was
+    allocated from. Mixing `hpool` with a per-VM pool corrupts both.
+*   **External pages:** `__hyp_attach_page` accepts pages outside
+    `[range_start, range_end)` and inserts them at order 0 without coalescing
+    — used for host donations. "Freed page is not in the pool's range" is
+    therefore not by itself a bug.
+
+**REPORT as bugs:**
+
+*   Touching `page->refcount` or `page->order` without `pool->lock`.
+*   Treating `hyp_alloc_pages()` failure as fatal (`WARN_ON` / `BUG_ON`) —
+    `-ENOMEM` is a normal runtime outcome.
+*   Allocating from one pool and freeing into another.
+
+## pKVM Page-Ownership Transitions
+
+pKVM tracks physical page ownership across three actors (host, hypervisor,
+guest). Ownership transitions (share, unshare, donate) are the highest-density
+pKVM-specific bug pattern and are in the attacker's direct reach from the
+host.
+
+- **Argument Validation Before Transition:** Every hypercall that initiates an
+  ownership transition MUST validate the supplied range arguments (base
+  address, size) against the current ownership state BEFORE modifying any EL2
+  metadata. Unvalidated ranges cause out-of-bounds metadata corruption.
+- **Cross-Check After Transition:** After completing a transition, EL2 MUST
+  verify that the resulting ownership state is consistent with what was
+  requested. Silent inconsistency propagates across subsequent transitions.
+- **Atomicity of State Updates:** Ownership metadata and page-table entries
+  for the affected range MUST be updated atomically from EL2's perspective.
+  Partial updates observable to other CPUs create TOCTOU windows.
+- **Reclaim Path Discipline:** The reclaim path for a dying guest MUST
+  enumerate pages by their recorded ownership state, not by the page-table
+  walk. Pages already donated but whose metadata was not updated are otherwise
+  leaked.
+
+**REPORT as bugs:**
+- Ownership transition hypercalls that proceed without fully validating the
+  supplied range against current EL2 metadata.
+- Reclaim or teardown paths that walk the page table rather than the ownership
+  metadata to enumerate pages to free.
+
+## FF-A Interface Validation
+
+The Firmware Framework for Arm (FF-A) interface between EL2 and EL3 is a large
+attack surface with a recurring pattern of missing range/offset checks.
+
+- **Offset and Length Validation:** Every FF-A memory-sharing hypercall that
+  accepts a buffer descriptor MUST validate the `offset` and `length` fields
+  against the actual buffer size before dereferencing. Missing checks allow
+  the host to construct a descriptor that causes EL2 to read out-of-bounds
+  hypervisor memory.
+- **Version Negotiation:** EL2 MUST enforce the agreed FF-A version; downgrade
+  responses from EL3 must be rejected correctly and not silently used as a
+  higher version. Correct acquire/release ordering is required for
+  version-negotiation state visible across CPUs.
+- **Unsupported Interface Masking:** Optional FF-A 1.1/1.2 interfaces that
+  pKVM does not implement MUST be masked in responses to `FFA_FEATURES`
+  queries. Unmasked optional interfaces are advertised as supported, leading
+  to incorrect guest behavior.
+
+**REPORT as bugs:**
+- FF-A handlers that use a host-supplied offset or length without
+  bounds-checking against the declared buffer size.
+- `FFA_FEATURES` responses that advertise optional interfaces not implemented
+  by pKVM.
+
+## Trap Register Initialization and Protected-vs-Unprotected Divergence
+
+- **Initialization in EL2:** Trap configuration registers (`HFGRTR_EL2`,
+  `MDCR_EL2`, etc.) MUST be initialized in EL2-private context, not relied
+  upon from values written by the host. On protected VMs, the hyp initializes
+  trap state from hardcoded architectural constants; on non-protected VMs, a
+  copy of the host-set values is made on VCPU load. Missing initialization
+  leaves traps in UNKNOWN state after warm reset.
+- **FGT registers are EL2-only:** `HFGRTR_EL2`, `HFGWTR_EL2`, `HFGITR_EL2`,
+  `HDFGRTR_EL2`, `HDFGWTR_EL2`, and `HAFGRTR_EL2` UNDEF on EL1/EL0 access
+  (absent nested virt). The host cannot write them architecturally, so reading
+  them back after an EL2-side write (e.g., to verify a just-applied
+  configuration) is safe and is NOT a "reading host-written state" violation.
+  The rule below applies to registers the host can write, such as `SCTLR_EL1`
+  or `HCR_EL2`.
+- **Copy on VCPU Load:** For non-protected pKVM guests, FGT trap registers
+  MUST be copied from the host VCPU (`hyp_vcpu->host_vcpu->arch.fgt`) to the
+  hyp VCPU (`hyp_vcpu->vcpu.arch.fgt`) on each VCPU load. Stale hyp-side
+  copies cause incorrect trap behavior for the next guest entry.
+- **MTE / ID Register Initialization:** MTE flag initialization and ID
+  register initialization for protected VMs must follow the protected-VM path,
+  not the non-protected path. Using the wrong path silently leaves per-VM
+  security flags in an incorrect state.
+
+**REPORT as bugs:**
+- Hyp code that reads trap configuration from host-written registers rather
+  than EL2-private hyp state.
+- VCPU-load paths that do not refresh the hyp-side FGT register copy from the
+  host VCPU.
+
+## SMC imm16 / SMCCC Pass-Through Rules
+
+EL2 controls which `SMC` encodings the host is permitted to forward to EL3.
+This gating is part of the pKVM trust boundary.
+
+- **imm16 == 0 Enforcement:** The host is only permitted to use `SMC`
+  instructions with `imm16 == 0`. Any `SMC` with a non-zero `imm16` MUST be
+  rejected by EL2 before forwarding to EL3. This prevents the host from
+  exploiting firmware interfaces not intended for guest use.
+
+**REPORT as bugs:**
+- SMC pass-through paths that forward SMC instructions to EL3 without checking
+  that `imm16 == 0`.
+
+## Huge-Page Handling under pKVM
+
+Large-page (block-descriptor) handling in protected-mode stage-2 is a distinct
+failure mode from normal page faults.
+
+- **Protected-Mode Size Validation:** When installing a stage-2 mapping for a
+  protected VM, the mapping granule MUST be validated against the requested
+  fault granule. Installing a larger block mapping for a fault that expected a
+  page-size mapping silently breaks isolation.
+- **Range Adjustment on Stage-2 Fault:** The range covered by a stage-2 fault
+  must be computed from the IPA and the level of the faulting entry, not from
+  the host-supplied VMA shift. A stale or host-manipulated VMA shift produces
+  an incorrect range adjustment.
+
+**REPORT as bugs:**
+- Protected-mode fault handlers that install block descriptors without
+  verifying the block granule matches the expected fault size.
+- Fault handlers that derive the mapping range from the host VMA shift without
+  re-validating against the IPA alignment.
+
+## `WARN_ON` Semantics at EL2
+
+At EL2 in nVHE/pKVM, both `BUG_ON()` and `WARN_ON()` expand to `BRK` (via
+`__BUG_FLAGS` in `arch/arm64/include/asm/bug.h`), which the hyp panic handler
+treats as fatal. There is no "warn and continue" semantics for these macros at
+EL2 — code after a triggered `WARN_ON` is unreachable. The rule below applies
+to any EL2 invocation whose expansion ultimately reaches that `BRK`; if a
+patch uses a warning primitive that does not, the rule does not apply.
+
+**Test for any `WARN_ON(cond)` at EL2: can `cond` evaluate true through any
+contract-permitted input — or only through a violation of EL2's own
+invariants?**
+
+*   *Through contracted inputs* (`WARN_ON` wrong): host-supplied input
+    post-de-privilege, allocator/lookup outcomes, hardware/firmware return
+    values, concurrency races, anything timeout/poll-driven.
+*   *Only through invariant violation* (`WARN_ON` correct): values from EL2's
+    own just-completed state — a slot EL2 just populated being NULL, a
+    refcount EL2 just incremented being zero, an internal data structure EL2
+    just initialized being inconsistent.
+
+If a separate bug elsewhere makes an EL2-internal invariant violatable (e.g.,
+a slot left NULL by a different lifecycle bug), flag *that* bug — do not
+demote the local `WARN_ON`. `WARN_ON` defends the invariant; chaining "the
+invariant might be broken elsewhere" into "therefore this assertion is wrong"
+defeats its purpose.
+
+A `WARN_ON` flagged "wrong" by this test is a *correctness* finding: the
+assertion is the wrong tool, the function should error out instead. Whether it
+is also a *bug* is judged separately by the reachability test in §pKVM Threat
+Model and Scope. A host-kernel-only reachable wrong `WARN_ON` is a hardening
+improvement. A guest- or host-userspace-reachable one is a bug.
+
+**Dead-branch trap:** patterns like `WARN_ON(err); do_fallback();` or `if
+(WARN_ON(err)) goto out;` at EL2 do NOT execute the recovery path — the WARN
+path panics. The error-handling code is dead. Reviewers familiar with
+host-side `WARN_ON` semantics routinely miss this.
+
+Do not invoke `CONFIG_BUG=n` to upgrade a defensive `WARN_ON` into a
+"null-deref" claim. `CONFIG_BUG=n` is an EXPERT-only opt-out; the test above
+(reachability through contracted inputs) determines correctness, not the
+hypothetical no-op behavior of a corrected assertion.
+
+### BUG() and hyp_panic() are equivalent at EL2 nvhe
+
+Plain `BUG()` (not just `BUG_ON()`) at EL2 nvhe expands to `BRK BUG_BRK_IMM`.
+That instruction is caught by the EL2 exception vector
+(`kvm_unexpected_el2_exception`), which calls
+`__guest_exit_restore_elr_and_panic`, which calls `hyp_panic()`. `BUG()` and a
+direct `hyp_panic()` call are therefore functionally equivalent at EL2 — both
+terminate with a hyp panic, no return.
+
+The prevailing convention in `arch/arm64/kvm/hyp/nvhe/` is `BUG()`: 6 call
+sites across the `*.c` files (4 in `hyp-main.c` alone) versus 2 direct
+`hyp_panic()` call sites. **Do not flag a `BUG()` ↔ `hyp_panic()` substitution
+as a regression** — neither form is more or less correct than the other, and
+`BUG()` is the house style.
+
+## Quick Checks
+
+*   **Dead State Invariant:** On any fatal initialization error or
+    host-triggered corruption, the VM MUST be marked as definitively "dead"
+    (e.g., via `is_dying` in `struct kvm_protected_vm`). This acts as a
+    fail-safe to prevent resource reassignment logic from running on corrupted
+    metadata.
+*   **Asynchronous Engine Synchronization (Speculation):** Clearing
+    control/enable bits for asynchronous hardware engines (e.g., profiling,
+    tracing, or debug extensions) is **insufficient** to stop speculative page
+    table walks or memory accesses. When switching translation regimes (e.g.,
+    Guest <-> Host switches at EL2), software MUST execute the architecturally
+    mandated synchronization sequence for all active engines (e.g., `PSB
+    CSYNC` for profiling) followed by a speculative execution barrier (e.g.,
+    `SB`, `DSB` + `ISB`) to definitively halt out-of-context execution.
+    - **REPORT as bugs:** Code that disables an asynchronous feature but fails
+      to execute a subsequent synchronization barrier before changing the
+      translation context (e.g., updating `VTTBR_EL2` or `TTBRn_ELx`).

--- a/kernel/subsystem/kvm-arm64.md
+++ b/kernel/subsystem/kvm-arm64.md
@@ -1,0 +1,221 @@
+# ARM64 KVM (Host/EL1) Subsystem Details
+
+This guide covers invariants and bug patterns for the ARM64-specific KVM
+implementation running at EL1 (Host), derived from historical fixes and the
+ARM Architecture Reference Manual (ARM ARM).
+
+## VM & VCPU Lifecycle Initialization
+
+ARM64 KVM requires a strict ordering of initialization before a guest can
+execute. Violating this results in uninitialized hardware state or
+architectural inconsistencies.
+
+> Improper initialization causes **Hypervisor Aborts**, **Guest Execution
+> Failures**, and **-EPERM/-ENOEXEC** errors from the KVM API.
+
+*   **Virtual ID Register Initialization:** Virtual registers such as
+    `VMPIDR_EL2` and `VPIDR_EL2` reset to an **UNKNOWN** value on Warm reset.
+    They MUST be initialized by software before entering EL1 for the first
+    time.
+*   **Feature Locking & Finalization:** Architectural features that modify
+    guest-visible register layouts or system register behavior (e.g., vector
+    or tagging extensions) MUST be finalized and locked (via
+    `kvm_arm_vcpu_finalize()`) before the first VCPU entry. The implementation
+    MUST reject any attempts to modify feature configurations once the guest
+    has entered the `RUNNING` state.
+*   **Predicate for "guest has started running":** Use
+    `vcpu_has_run_once(vcpu)` (defined in `arch/arm64/include/asm/kvm_host.h`
+    — checks `vcpu->pid`, which `kvm_arch_vcpu_run_pid_change()` populates on
+    the first guest entry). Do NOT use `kvm_vcpu_initialized(vcpu)` for this
+    question: it reflects only whether `KVM_ARM_VCPU_INIT` has been called and
+    remains true forever after, including mid-run and post-run. Any
+    cap/ioctl/sysreg gate whose intent is "reject after the guest has run"
+    must use `vcpu_has_run_once()`; `kvm_vcpu_initialized()` answers a
+    different question (was init done) and silently accepts post-run
+    reconfiguration.
+
+    ```c
+    /* WRONG: passes once KVM_ARM_VCPU_INIT has happened, including after KVM_RUN */
+    if (!kvm_vcpu_initialized(vcpu))
+            return -EBUSY;
+
+    /* CORRECT: rejects once the guest has actually started executing */
+    if (vcpu_has_run_once(vcpu))
+            return -EBUSY;
+    ```
+*   **First-Run Resource Synchronization:** VGIC mapping and trap calculation
+    MUST be finalized before the VCPU enters guest mode for the first time.
+    The kernel utilizes internal safety nets (e.g.,
+    `kvm_arch_vcpu_run_pid_change()`) to enforce this ordering during the
+    first VCPU transition.
+*   **VGIC Mapping:** Virtual GIC resources MUST be mapped to the guest (via
+    `kvm_vgic_map_resources()`) before the first VCPU run.
+*   **Trap Calculation:** `kvm_calculate_traps()` must be invoked after all
+    feature flags and system registers are finalized, but before the first
+    VCPU entry.
+
+**REPORT as bugs:**
+*   Attempting to run a VCPU without first calling the relevant finalization
+    ioctls.
+*   Modifying guest feature registers (e.g., `ID_AA64*`) after the first VCPU
+    has entered the `RUNNING` state.
+*   Gating "has the guest started running" with `kvm_vcpu_initialized()`
+    instead of `vcpu_has_run_once()` — accepts post-run reconfiguration.
+*   **UAPI Feature Exposure:** Exposing `ID_AA64*` register fields to
+    userspace for hardware features that are not explicitly supported or fully
+    implemented. **Reviewer check:** Ensure any exposed bit has a
+    corresponding enablement/trap configuration in `HCR_EL2`, `CPTR_EL2`, or
+    `MDCR_EL2`.
+
+## Architectural State Management (PSCI & Reset)
+
+The consistency of guest architectural state across resets and power
+transitions is critical.
+
+> State management bugs lead to **Incorrect Execution Flow**, **Register
+> Corruption**, and **Security Bypasses**.
+
+*   **Warm Reset (PSCI CPU_ON):** Most system registers reset to an
+    **UNKNOWN** value on warm reset. Software MUST explicitly initialize the
+    execution environment, including disabling EL2 traps (`HCR_EL2`,
+    `CPTR_EL2`, `CNTHCTL_EL2`) and ensuring `HCR_EL2.RW == 1` for AArch64
+    guests. Note: on hardware without `FEAT_AA32EL1`, `HCR_EL2.RW` is RAO/WI
+    and the write is architecturally redundant but harmless.
+*   **Guest Identification & Affinity Sanity:** Identifiers presented to the
+    guest for routing or identification (e.g., `MPIDR_EL1` affinity values,
+    GIC target IDs) MUST be unique and architecturally consistent across all
+    VCPUs. KVM MUST NOT implement workarounds to accommodate guest
+    configurations that violate the ARM ARM.
+*   **Exception Injection Ordering:** Exception injection MUST preserve
+    `ELR_EL1`/`SPSR_EL1` across exit/entry. Miscoordination between exception
+    injection state and the synchronous abort/SError handling path leads to
+    ELR clobber (`KVM: arm64: Fix clobbered ELR in sync abort/SError`).
+*   **Stage 2 Teardown:** Stage 2 teardown must serialize against concurrent
+    `mmu_notifier` callbacks; freeing a page table while a notifier walker can
+    still observe it causes UAF or double-free. Fixes chain: `KVM: arm64: Only
+    drop references on empty tables in stage2_free_walker`, `Fix double-free
+    following kvm_pgtable_stage2_free_unlinked()`, `Fix memory leak on stage2
+    update of a valid PTE`.
+
+**REPORT as bugs:**
+*   Patches that introduce logic to handle non-unique guest CPU affinities or
+    relax identification register validation.
+*   Exception injection paths that modify `ELR_EL1`/`SPSR_EL1` without
+    atomically resolving the pending exception state before the next guest
+    entry.
+*   Teardown sequences that destroy page tables while the `mmu_notifier` could
+    still be active.
+
+## VGIC CPU Interface Access
+
+The Virtual GIC CPU interface registers are highly sensitive to software
+access patterns.
+
+> Violating GIC interface access rules causes **Interrupt Hangs**, **Spurious
+> Exceptions**, or **UNPREDICTABLE CPU Behavior**.
+
+*   **Priority Register Writes:** Writing `ICV_AP<0|1>R<n>_EL1` to any value
+    other than the last read value or all-zeros (when there are no Group-N
+    active priorities), or out of order (AP0 must precede AP1), **may result
+    in UNPREDICTABLE behavior** of the virtual interrupt prioritization. These
+    registers should only be touched for context switching or power
+    management.
+*   **Self-Synchronization:** Reads of `ICV_IAR0_EL1` and `ICV_IAR1_EL1` are
+    self-synchronizing when interrupts are masked by the PE (`PSTATE.{I,F} ==
+    {0,0}`). Writes to `ICV_PMR_EL1` are strictly self-synchronizing (no ISB
+    required).
+*   **System Register Interface Gating:** Access to the memory-mapped GIC
+    virtual CPU interface (`GICV_*`) is gated by `ICC_SRE_EL1_NS.SRE` (not by
+    `GICD_CTLR.ARE`). When `SRE == 1`, `GICV_*` registers may be RAZ/WI;
+    software should use the system-register interface instead.
+
+## Quick Checks
+
+*   **HCR_EL2 Sync:** `HCR_EL2` writes that affect TLB-cached fields (`RW`,
+    `NV1`, `NV`, `E2H`, `FWB`, `DCT`) require TLB invalidation before
+    translation changes take effect — `ERET` alone does not flush these cached
+    fields. For non-TLB-cached fields, an `ERET` to EL1/0 acts as a CSE
+    provided `SCTLR_ELx.EOS == 1` (always check `FEAT_ExS` semantics in
+    nVHE/VHE paths). World-switch barrier placement differs between nVHE and
+    VHE paths; both must be verified independently.
+*   **MTE Feature Filtering:** Verify that MTE features are correctly filtered
+    in guest ID registers based on hardware support AND VM type (Protected vs.
+    Non-Protected).
+*   **Feature ID / RESx Writeable Mask:** `ID_AA64*` register fields exposed
+    to userspace must have correct writeable masks and runtime sanitization. A
+    field that is RES0 in the hardware but exposed as writable causes silent
+    guest misconfiguration. Every new field exposure must be paired with the
+    correct `kvm_id_reg_rw_mask` or RESx-handling entry and a corresponding
+    trap/enablement in `HCR_EL2`, `CPTR_EL2`, or `MDCR_EL2`.
+
+## VGIC LPI and vLPI Invariants
+
+VGIC LPI (Locality-specific Peripheral Interrupt) management involves a
+layered locking protocol and GICv4 VPE ownership rules that are a recurring
+source of bugs.
+
+- **vgic_irq / LPI xarray lock ordering:** Operations on `vgic_irq` structs
+  protected by `irq_lock` must not hold the LPI xarray lock simultaneously
+  unless the ordering is explicitly documented. Releasing and re-acquiring
+  `irq_lock` while the xarray lock is held violates the ordering and causes
+  deadlock.
+- **LPI xarray access in atomic context:** The LPI xarray lock must not be
+  held while calling `vgic_put_irq()` from a raw spinlock context; any path
+  that may call `vgic_put_irq()` must document that the LPI xarray lock may be
+  taken.
+- **GICv4 vLPI unmapping:** Unmapping a vLPI from a VPE MUST succeed on all
+  call paths; a failed unmap leaves a dangling forwarding entry. `WARN` on
+  unmap failures and treat them as bugs.
+- **vPE allocation gating:** vLPI mappings MUST NOT be attempted when vPE
+  allocation is disabled. Gate all forwarding setup on the vPE availability
+  check.
+
+**REPORT as bugs:**
+- New VGIC code that takes the LPI xarray lock while holding `irq_lock`
+  (unless the ordering is explicitly established).
+- vLPI forwarding setup that proceeds without verifying vPE allocation is
+  enabled.
+- Unmap paths that silently ignore or swallow vLPI unmap errors.
+
+## Stage-2 Page-Fault Handler Races
+
+The `user_mem_abort()` path and its pKVM equivalents have a recurring pattern
+of resource leaks and stale-state bugs.
+
+- **Page Leak on Error Paths:** Every early-exit error path in the fault
+  handler that has already resolved a PFN must drop the PFN reference before
+  returning. Missing PFN release on error causes page leaks.
+- **Memcache Initialization:** The `kvm_mmu_memory_cache` pointer passed into
+  the fault handler must be initialized before use; uninitialized pointer
+  dereferences produce NULL-deref crashes that are hard to trace back to the
+  fault handler.
+- **vma_shift Staleness:** The `vma_shift` value computed at fault-entry time
+  may be stale if the VMA is modified concurrently (e.g., during nested
+  hwpoison injection). Re-check VMA attributes after taking the mmu_lock.
+
+**REPORT as bugs:**
+- Error paths in `user_mem_abort()` or stage-2 fault handlers that return
+  without releasing a previously resolved PFN.
+- Fault handlers that dereference an uninitialized `kvm_mmu_memory_cache`
+  pointer.
+
+## GICv3 Trap Ordering (ICH_HCR_EL2)
+
+- **ICH_HCR_EL2.En synchronization:** Changes to `ICH_HCR_EL2.En` are not
+  guaranteed to be seen by subsequent guest execution without an explicit
+  exit/re-entry cycle. When enabling or disabling GICv3 virtual CPU interface
+  traps, a forced guest exit must follow to flush the stale `ICH_HCR_EL2`
+  state in the CPU pipeline.
+- **Trap configuration ordering across entry/exit:** GICv3 trap bits in
+  `ICH_HCR_EL2` must be resynchronized early on guest entry (before the
+  LR/VMCR are loaded) to avoid a window where interrupts are delivered without
+  correct trap configuration.
+- **Protected vs. non-protected trap divergence:** In pKVM, GICv3 trap
+  initialization for protected VMs differs from non-protected guests; the
+  wrong path silently leaves traps inactive.
+
+**REPORT as bugs:**
+- Code that modifies `ICH_HCR_EL2.En` without a subsequent guest exit to flush
+  the change.
+- Guest-entry paths that load LRs or VMCR before re-synchronizing
+  `ICH_HCR_EL2` trap bits.

--- a/kernel/subsystem/kvm.md
+++ b/kernel/subsystem/kvm.md
@@ -1,0 +1,229 @@
+# KVM Subsystem Details
+
+This guide covers cross-architecture KVM invariants, locking hierarchies, and
+memory management API contracts derived from `Documentation/virt/kvm/` and
+historical fixes.
+
+## API and ABI Quick Checks
+
+Before diving into the locking and MMU details below, scan the diff for the
+following cross-cutting issues. They come up repeatedly across KVM subsystems
+and are easy to miss in a focused review:
+
+- **New guest-visible features default off and are enumerable.** Any new
+  behaviour the guest can observe (a new ioctl, a new VM or vCPU capability, a
+  new exit reason, a new emulated instruction) MUST be off by default and
+  discoverable through the architecture's standard enumeration interface, for
+  example `KVM_CHECK_EXTENSION` / `KVM_CAP_*`, `KVM_GET_SUPPORTED_CPUID2` on
+  x86, or ID-register feature bits on ARM64. Silently-on features break live
+  migration and make capability negotiation impossible.
+- **No guest- or host-userspace-reachable `WARN_ON` / `BUG_ON`.** A `WARN_ON`
+  or `BUG_ON` whose condition can be driven by a malicious guest or by an
+  unprivileged host-userspace process is a host-side denial of service.
+  Convert to `pr_warn_once()`, return an error to userspace, or just drop the
+  assertion. Asserts are fine for "the kernel itself is buggy" paths, not for
+  adversary-reachable inputs.
+- **Long loops are a recurring bug class, but the fix is flow-specific.**
+  Loops over guest-driven counts (memslots, vCPUs, GFN ranges,
+  rmaps/SPTEs, pinned pages) with per-iteration MMU activity (invalidate,
+  zap, clflush, unmap) have a long history of soft-lockup and RCU-stall
+  fixes. There is no universal mitigation: yielding under `kvm->mmu_lock`
+  can hurt fault throughput, and in extreme cases dropping the lock and
+  forcing retries can starve the guest. Treat this as background context
+  for new long-running paths, not a checklist item demanding
+  `cond_resched()` or any other specific yield mechanism.
+- **New memslot and vCPU flags default to immutable.** A flag that can be
+  cleared or flipped after it is first set creates state-machine transitions
+  that almost no caller is prepared for; recent issues around
+  `KVM_MEM_GUEST_MEMFD` and post-`KVM_ARM_VCPU_INIT` vCPU-model changes are
+  concrete examples. Default new flags to set-once and require an explicit
+  justification to make them mutable.
+
+## KVM Locking Hierarchy
+
+KVM uses a complex hierarchy of global and per-VM locks. Violating this order
+results in circular deadlocks or use-after-free (UAF) scenarios.
+
+> Improper lock ordering causes **ABBA Deadlocks** and **System Hangs**.
+
+The authoritative lock ordering is `Documentation/virt/kvm/locking.rst`. Read
+it whenever a change touches `kvm_lock`, `kvm->lock`, `vcpu->mutex`,
+`kvm->slots_lock`, `kvm->srcu`, or `kvm->mmu_lock`. Do not rely on this guide
+as a substitute. The bullets below capture the specific failure modes a
+reviewer should flag, anchored on that doc.
+
+- **SRCU Constraint:** `synchronize_srcu(&kvm->srcu)` is invoked while holding
+  `kvm->lock`, `vcpu->mutex`, or `kvm->slots_lock`. Consequently, **none** of
+  these mutexes may be acquired while holding a `srcu_read_lock(&kvm->srcu)`.
+- **`slots_arch_lock` Exception:** The architecture-specific memslot lock
+  (e.g., in `arch/arm64/kvm/`) is typically NOT involved in SRCU
+  synchronization and MAY be acquired inside an SRCU read-side critical
+  section.
+- **MMU Notifier Sleep Safety:** MMU notifier callbacks
+  (`invalidate_range_start` / `_end`) MUST NOT take `kvm->slots_lock` or
+  `kvm->slots_arch_lock`, since memslot modification waits on those locks from
+  inside the notifier quiescence.
+
+**REPORT as bugs:**
+- Acquiring `kvm->lock`, `vcpu->mutex`, or `kvm->slots_lock` inside an SRCU
+  read-side critical section.
+- Holding `vcpu->mutex` and then attempting to acquire the parent `kvm->lock`.
+- Performing any sleepable operation (`kzalloc` without `GFP_ATOMIC`,
+  `mutex_lock`, `copy_from_user`) while holding `kvm->mmu_lock`.
+
+## Memory Management and Memslots
+
+KVM manages guest memory through "memslots." Accessing these without proper
+SRCU protection or synchronization leads to **Use-After-Free (UAF)** or stale
+translation usage.
+
+> Failure to protect memslot iteration results in **Kernel Panics** (UAF) or
+> **Silent Data Corruption** during VM migration.
+
+- **Memslot Consistency (Read-Side):** Accessing guest memory mapping metadata
+  (memslots) from the fast path (e.g., page faults or instruction emulation)
+  requires a non-preemptible or RCU-protected environment. This ensures that
+  the reader never observes a partially updated or freed mapping structure
+  during a concurrent memslot update. In KVM, this is achieved by holding
+  `kvm->srcu`.
+- **Writer Context Exception:** Access without SRCU is permitted only if
+  **`kvm->slots_lock`** is held (e.g., during memslot updates).
+- **Update API:** All changes to memslots (flags, address ranges) MUST go
+  through `kvm_set_memory_region()`. Manual modification of memslot structures
+  is forbidden.
+
+**REPORT as bugs:**
+- Accessing memslots or calling address translation helpers (e.g.,
+  `gfn_to_hva()`) without holding `kvm->srcu` (unless in a writer context with
+  `slots_lock`).
+- Manual bit-flipping in memslot flags (e.g., `KVM_MEM_LOG_DIRTY_PAGES`)
+  outside the official update path.
+
+```c
+// WRONG: Accessing memslots without SRCU protection
+struct kvm_memslots *slots = kvm_memslots(vcpu->kvm);
+hva = __gfn_to_hva_memslots(slots, gfn); // Potential UAF
+
+// CORRECT: Protecting with SRCU
+int idx = srcu_read_lock(&kvm->srcu);
+struct kvm_memslots *slots = kvm_vcpu_memslots(vcpu);
+hva = __gfn_to_hva_memslots(slots, gfn);
+srcu_read_unlock(&kvm->srcu, idx);
+```
+
+## Invalidation Retry Protocol (MMU Notifiers)
+
+When KVM handles a page fault, it must synchronize with concurrent host MMU
+invalidations to ensure it does not install a stale mapping.
+
+> Missing the retry check allows KVM to install **Stale Translations**,
+> leading to memory corruption or guest-visible data leakage.
+
+- **The Mandatory Sequence:**
+    1. **Capture:** Store the current `mmu_invalidate_seq`.
+    2. **Resolve:** Translate the guest address (HVA/GPA) to a physical frame
+       (PFN).
+    3. **Lock:** Acquire the `kvm->mmu_lock`.
+    4. **Check:** Verify `!mmu_invalidate_retry(kvm, captured_seq)`.
+    5. **Install:** Commit the mapping to KVM's page tables.
+    6. **Unlock:** Release `kvm->mmu_lock`.
+- **Generation Count Invariant:** The retry check combines the global
+  `mmu_invalidate_seq` with the in-progress gfn range; neither alone is
+  sufficient. The sequence counter is the primary generation-safety check; the
+  gfn range reduces false-positives.
+- **Locking Invariant (gating check):** The retry check that gates
+  installation MUST be performed while `kvm->mmu_lock` is held, and the lock
+  MUST remain held until the translation is fully installed. Pre-acquisition
+  "unsafe" retry checks via `mmu_invalidate_retry_gfn_unsafe()` are a
+  legitimate fast-path optimization to avoid lock contention; they do NOT
+  replace the gating check, and reviewers should not flag them as bugs.
+
+**REPORT as bugs:**
+- Installing a mapping based only on the result of an unsafe retry check,
+  without re-checking under `kvm->mmu_lock`.
+- Resolving the PFN *after* capturing the sequence or *after* acquiring the
+  lock (violates resolution-to-installation atomicity).
+- Dropping `kvm->mmu_lock` between the retry check and the installation of the
+  page table entry.
+
+## VCPU Lifecycle and Preemption
+
+`vcpu_load()` and `vcpu_put()` manage the attachment of a virtual CPU to a
+physical CPU.
+
+> Failing to manage VCPU attachment leads to **Leaked Preempt Notifiers**,
+> causing NULL dereferences in the scheduler, and **Hardware State
+> Corruption**.
+
+- **Mandatory Usage:** These MUST be paired and are mandatory for operations
+  interacting with physical-CPU-dependent state (hardware registers, timers,
+  preempt notifiers).
+- **Side Effects:** `vcpu_load()` registers preempt notifiers. Failing to call
+  `vcpu_put()` leads to leaked notifiers and `NULL` pointer dereferences in
+  `kvm_sched_out()`.
+
+**REPORT as bugs:**
+- Missing `vcpu_load()` or `vcpu_put()` around KVM IOCTLs that modify
+  architectural or hardware-switched state.
+
+## Quick Checks
+
+- **VCPU Requests:** `kvm_make_request()` internally issues `smp_wmb()` before
+  setting the request bit, paired with `smp_mb__after_atomic()` in
+  `kvm_check_request()`. Callers MUST NOT add manual barriers around
+  `kvm_make_request()`. The IPI-kick path (`kvm_vcpu_kick`) pairs with a full
+  `smp_mb()` and the vcpu's `IN_GUEST_MODE` flag — see
+  `Documentation/virt/kvm/vcpu-requests.rst` "Ensuring Requests Are Seen".
+- **Updates to hardware-shared SPTE bits preserve concurrent hardware
+  writes.** When KVM updates SPTE bits that the hardware page-table walker
+  also writes (Dirty/Access on leaf entries), the update must not clobber a
+  concurrent hardware update. Atomic single-instruction operations (e.g., x86
+  XCHG, atomic AND, `cmpxchg`) are all acceptable; a `cmpxchg` loop is not
+  required. Non-leaf SPTEs for bits the architecture doesn't currently track
+  (e.g., Access on non-leaf SPTEs in KVM x86) can use plain writes. GICv4
+  virtual pending state is ARM64-specific; see kvm-arm64.md.
+- **cpus_read_lock() placement:** `cpus_read_lock()` is the outermost KVM
+  lock. Taking it outside `kvm_lock` is the official ordering, but it is
+  easily triggered inadvertently while holding `kvm_lock`. Reviewers should
+  flag any new path that calls `cpus_read_lock()` with `kvm_lock` already
+  held.
+- **MMU Notifier Pairing Invariant:** Each `invalidate_range_start()` is
+  paired with exactly one `invalidate_range_end()` using the same memslots
+  array. The retry-protocol sequence counter depends on this pairing; broken
+  pairing produces false "retry not needed" results.
+
+## Dirty Ring and Dirty Bitmap
+
+KVM supports two dirty-tracking mechanisms (ring and bitmap) that can run
+concurrently. Incorrect synchronization between them leads to lost dirty
+information or NULL pointer dereferences.
+
+- **Ring-to-Bitmap Flush:** When the dirty ring is full, dirty information
+  MUST be flushed unconditionally to the backup bitmap before the ring is
+  cleared. Conditional flushes can silently lose pages whose dirty entries
+  were overwritten.
+- **Bitmap Range Alignment:** `KVM_CLEAR_DIRTY_LOG` operates on a bitmap range
+  that must be aligned to 64 bits; unaligned ranges corrupt adjacent dirty
+  state.
+
+**REPORT as bugs:**
+- Dirty-ring flush paths that conditionally skip the bitmap backup.
+- `KVM_CLEAR_DIRTY_LOG` handlers that do not check for bitmap-size alignment.
+
+## pfn Cache and Private Memslots
+
+- **gfn→pfn Cache Refresh Protocol:** The `gfn_to_pfn_cache` refresh uses the
+  same sequence-counter discipline as the MMU notifier retry protocol. Cache
+  refresh MUST re-check `mmu_invalidate_seq` after pinning the page to close
+  the TOCTOU window. Multiple concurrent invalidations can overlap during the
+  pin; the sequence counter catches all of them.
+- **Private Memslot Overlap:** Public and private (guest_memfd) memslots MUST
+  NOT overlap in GPA space. Overlap detection MUST be enforced during
+  `KVM_SET_USER_MEMORY_REGION2` handling; overlapping private/public memslots
+  produce UAF or silent data corruption during fault injection.
+
+**REPORT as bugs:**
+- `gfn_to_pfn_cache` refresh paths that do not re-check the invalidation
+  sequence after pinning.
+- `KVM_SET_USER_MEMORY_REGION2` handlers that permit GPA overlap between
+  private and public memslots.

--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -76,6 +76,7 @@ regexes
 | Rust | any Rust code | rust.md |
 | KVM | virt/kvm/, include/linux/kvm*, kvm_ | kvm.md |
 | ARM64 | arch/arm64/, sysreg | arm64.md |
+| ARM64 KVM (EL1/Host) | arch/arm64/kvm/ | kvm-arm64.md |
 
 ## Optional Patterns
 

--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -75,6 +75,7 @@ regexes
 | KHO (Kexec Handover) | lib/test_kho.c, kho_, kho_is_enabled, kho_retrieve_subtree, kho_preserve_folio, kho_add_subtree, register_kho_notifier | kho.md |
 | Rust | any Rust code | rust.md |
 | KVM | virt/kvm/, include/linux/kvm*, kvm_ | kvm.md |
+| ARM64 | arch/arm64/, sysreg | arm64.md |
 
 ## Optional Patterns
 

--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -74,6 +74,7 @@ regexes
 | Objtool | tools/objtool/, INSN_BUG, INSN_TRAP, decode.c | objtool.md |
 | KHO (Kexec Handover) | lib/test_kho.c, kho_, kho_is_enabled, kho_retrieve_subtree, kho_preserve_folio, kho_add_subtree, register_kho_notifier | kho.md |
 | Rust | any Rust code | rust.md |
+| KVM | virt/kvm/, include/linux/kvm*, kvm_ | kvm.md |
 
 ## Optional Patterns
 

--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -82,7 +82,7 @@ and symbols regexes.
 | KVM | virt/kvm/, include/linux/kvm*, kvm_ | kvm.md |
 | ARM64 | arch/arm64/, sysreg | arm64.md |
 | ARM64 KVM (EL1/Host) | arch/arm64/kvm/ | kvm-arm64.md |
-| ARM64 Hyp (EL2) | arch/arm64/kvm/hyp/, __hyp_, arch/arm64/include/asm/kvm.*\.h | hyp-arm64.md |
+| ARM64 Hyp (EL2) | arch/arm64/kvm/hyp/, __hyp_, arch/arm64/include/asm/kvm.*\.h, drivers/iommu/arm/arm-smmu-v3/pkvm/ | hyp-arm64.md |
 
 ## Optional Patterns
 

--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -77,6 +77,7 @@ regexes
 | KVM | virt/kvm/, include/linux/kvm*, kvm_ | kvm.md |
 | ARM64 | arch/arm64/, sysreg | arm64.md |
 | ARM64 KVM (EL1/Host) | arch/arm64/kvm/ | kvm-arm64.md |
+| ARM64 Hyp (EL2) | arch/arm64/kvm/hyp/, __hyp_, arch/arm64/include/asm/kvm.*\.h | hyp-arm64.md |
 
 ## Optional Patterns
 

--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -1,12 +1,17 @@
 # Subsystem Guide Index
 
-Load subsystem guides from the prompt directory based on what the code touches.
-Each guide contains subsystem-specific invariants, API contracts, and common
-bug patterns. Each subsystem guide may reference additional pattern files to
-load conditionally.
+Load subsystem guides from the prompt directory based on what the code
+touches. Each guide contains subsystem-specific invariants, API
+contracts, and common bug patterns. Each subsystem guide may reference
+additional pattern files to load conditionally.
 
-The triggers column below includes both path names, function calls, and symbols
-regexes
+A change can match multiple rows. Load **every** matching guide, not
+just the deepest or most specific. For example, code touching
+`arch/arm64/kvm/hyp/` matches the ARM64, KVM, ARM64 KVM (EL1/Host),
+and ARM64 Hyp (EL2) rows — all four guides apply.
+
+The triggers column below includes both path names, function calls,
+and symbols regexes.
 
 ## Subsystem Guides
 


### PR DESCRIPTION
## Summary

This series adds four new subsystem guides covering ARM64, KVM,
ARM64-KVM (EL1/Host), and the ARM64 Hypervisor at EL2,
plus the trigger-table glue to load them additively. The guides were
distilled from ~5 years of `Fixes:`-tagged commits in the relevant
trees, mailing-list maintainer feedback, and the ARM Architecture
Reference Manual, then iterated against adversarial logic stress-
testing and review feedback on the pKVM SMMUv3 series.

The series also bundles two small standalone fixes:

- A `subsystem.md` prose clarification that trigger matches are
  *additive*. Eval runs across various models showed a shared failure
  mode where reviewers defaulted to "deepest match wins" and missed
  higher-level guides (e.g. a change in `arch/arm64/kvm/hyp/` only
  loaded `hyp-arm64.md` and skipped `arm64.md`, `kvm.md`, and
  `kvm-arm64.md`). Table content is unchanged.
- A `review-core.md` one-liner that directs the no-semcode fallback
  at `git show <sha>` instead of `git diff` against HEAD.
  `review_one.sh` checks out a worktree with the commit already
  applied, so `git diff` returns nothing.

## Series

1. `kernel: add generic KVM subsystem guide`
2. `kernel: add ARM64 architecture subsystem guide`
3. `kernel: add ARM64 KVM (Host/EL1) subsystem guide`
4. `kernel: add ARM64 Hypervisor (EL2) subsystem guide`
5. `subsystem: clarify additive matching of subsystem triggers`
6. `subsystem: route drivers/iommu/arm/arm-smmu-v3/pkvm/ to hyp-arm64`
7. `review-core: don't use git diff when the commit is already applied`

## Impact / evidence

This guide set has been shipping via downstream changes
for a while. Public signals:

- Upstream patches accepted with assistance from this guide set:
  https://lore.kernel.org/all/20260501112149.2824881-1-tabba@google.com/
- Citation of these guides on Mostafa Saleh's pKVM SMMUv3 v6 cover letter:
  https://lore.kernel.org/all/20260501111928.259252-1-smostafa@google.com/
