### PR TITLE
Reduce false positives around alignment semantics

### DIFF
--- a/kernel/subsystem/alignment.md
+++ b/kernel/subsystem/alignment.md
@@ -1,0 +1,65 @@
+# Alignment Helpers
+
+## Generic ALIGN Semantics
+
+`ALIGN(x, a)` rounds `x` **up** to an `a` boundary. If `x` is already aligned,
+the result is `x`, not the next boundary. `ALIGN_DOWN(x, a)` rounds `x` **down**
+to an `a` boundary. `IS_ALIGNED(x, a)` tests whether `x` is already aligned.
+
+The alignment argument `a` is expected to be a power-of-two value.
+
+For a half-open range `[start, end)`, use `ALIGN_DOWN(start, a)` and
+`ALIGN(end, a)` to cover the whole range. Use `ALIGN(start, a)` and
+`ALIGN_DOWN(end, a)` only when selecting fully-contained aligned chunks.
+
+## Page Alignment Helpers
+
+`PAGE_ALIGN(addr)` is `ALIGN(addr, PAGE_SIZE)`. `PAGE_ALIGN_DOWN(addr)` is
+`ALIGN_DOWN(addr, PAGE_SIZE)`. `PAGE_ALIGNED(addr)` tests `PAGE_SIZE`
+alignment. These helpers operate on addresses, not PFNs.
+
+## Pageblock Alignment Helpers
+
+`pageblock_nr_pages` is `1UL << pageblock_order`. Pageblock helpers operate on
+PFNs, not byte addresses:
+
+```c
+#define pageblock_align(pfn)       ALIGN((pfn), pageblock_nr_pages)
+#define pageblock_aligned(pfn)     IS_ALIGNED((pfn), pageblock_nr_pages)
+#define pageblock_start_pfn(pfn)   ALIGN_DOWN((pfn), pageblock_nr_pages)
+#define pageblock_end_pfn(pfn)     ALIGN((pfn) + 1, pageblock_nr_pages)
+```
+
+`pageblock_start_pfn(pfn)` returns the inclusive start PFN of the pageblock
+containing `pfn`. `pageblock_end_pfn(pfn)` returns the exclusive end PFN of the
+pageblock containing `pfn`; when `pfn` is itself pageblock-aligned, this is the
+next pageblock boundary, not `pfn`.
+
+`pageblock_align(pfn)` rounds **up** to the first pageblock boundary at or after
+`pfn`. It is not equivalent to `pageblock_start_pfn(pfn)` for an unaligned PFN.
+
+Example with `pageblock_nr_pages == 1024`:
+
+| PFN | `pageblock_start_pfn()` | `pageblock_align()` | `pageblock_end_pfn()` |
+|-----|-------------------------|---------------------|-----------------------|
+| 2048 | 2048 | 2048 | 3072 |
+| 2049 | 2048 | 3072 | 3072 |
+
+For a half-open PFN range `[start_pfn, end_pfn)`, align the covering range with
+`pageblock_start_pfn(start_pfn)` and `pageblock_end_pfn(end_pfn - 1)` when the
+range is non-empty.
+
+## Common Review Mistakes
+
+- Treating `ALIGN(x, a)` as strictly greater than `x`; it returns `x` when
+  already aligned.
+- Treating `ALIGN_DOWN(x, a)` as a no-op for unaligned values; it moves to the
+  previous boundary.
+- Passing an order where a size/count is required. Use `1UL << order`,
+  `PAGE_SIZE << order`, or `pageblock_nr_pages`, not raw `order`.
+- Confusing byte-address helpers (`PAGE_ALIGN()`) with PFN helpers
+  (`pageblock_*_pfn()`).
+- Treating `pageblock_end_pfn(pfn)` as inclusive. It is an exclusive end PFN.
+- Passing an exclusive range end directly to `pageblock_end_pfn()` when the
+  intended input is the last PFN in the range; use `end_pfn - 1` for non-empty
+  half-open ranges.

--- a/kernel/subsystem/mm-folio.md
+++ b/kernel/subsystem/mm-folio.md
@@ -29,8 +29,6 @@ page boundaries:
 
 - `free_tail_page_prepare()` in `mm/page_alloc.c` -- skips `TAIL_MAPPING`
   check per metadata-carrying tail page
-- `NR_RESET_STRUCT_PAGE` in `mm/hugetlb_vmemmap.c` -- HVO vmemmap restore
-  count
 - `__dump_folio()` in `mm/debug.c` -- debug printing
 
 Common failure: updating one consumer but missing the others (no compile-time

--- a/kernel/subsystem/mm-largepage.md
+++ b/kernel/subsystem/mm-largepage.md
@@ -52,6 +52,12 @@ page whose flags word can be concurrently modified by another code path,
 unless the caller holds exclusive access to the entire page (e.g., during
 allocation before the page is visible, or during final freeing).
 
+## Compound Page PFN Natural Alignment
+
+An order-`n` compound page starts at a PFN naturally aligned to `1 << n`.
+Any subpage PFN in that compound page rounds down to the same head PFN with
+`pfn & ~((1UL << order) - 1)` or `ALIGN_DOWN(pfn, 1UL << order)`.
+
 ## Page Cache Reference Counting for Large Folios
 
 `__filemap_add_folio()` in `mm/filemap.c` adds `folio_nr_pages(folio)` extra

--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -22,6 +22,7 @@ regexes
 | Networking Drivers | drivers/net/, ethtool_ops, net_device_ops | networking-drivers.md |
 | Netlink | `genl_`, `nla_`, `NLA_`, `NLM_F_`, `nlmsg_`, `netlink_callback`, Documentation/netlink/specs/, files marked `YNL-GEN` | netlink.md |
 | MM Page Tables | `pte_*`, `pmd_*`, `pud_*`, `set_pte`, `ptep_*`, `tlb_*`, `page_vma_mapped_walk`, `walk_page_range`, `zap_pte_range`, mm/memory.c, mm/mprotect.c, mm/pagewalk.c | mm-pagetable.md |
+| Alignment Helpers | `ALIGN`, `ALIGN_DOWN`, `IS_ALIGNED`, `PAGE_ALIGN`, `PAGE_ALIGN_DOWN`, `pageblock_align`, `pageblock_aligned`, `pageblock_start_pfn`, `pageblock_end_pfn` | alignment.md |
 | MM Folio/Page Cache | `folio_*`, `page_folio`, `compound_head`, `filemap_*`, `xa_*`, `xas_*`, `page_cache_*`, mm/filemap.c, mm/swap.c, mm/truncate.c | mm-folio.md |
 | MM Large Folios/THP/Hugetlb | `huge_memory`, `hugetlb`, `split_huge_*`, `folio_test_large`, `hstate`, PMD sharing, mm/huge_memory.c, mm/hugetlb.c, mm/memory-failure.c | mm-largepage.md |
 | MM VMA Operations | `vma_*`, `mmap_*`, `vm_area_struct`, `vm_flags`, `anon_vma`, `maple_tree`, mm/vma.c, mm/mmap.c, mm/mmap_lock.c | mm-vma.md |


### PR DESCRIPTION
## Summary

This PR updates the Linux kernel review prompt knowledge base to reduce false positives caused by stale or incorrect assumptions around folio metadata, compound page alignment, and generic alignment helpers.

## Problems

- The start PFN of a compound page cannot be unaligned.
<img width="713" height="297" alt="image" src="https://github.com/user-attachments/assets/034d6db0-d320-4f3b-b308-9ef095965b5e" />

- pageblock_align() is **upward**-aligned
<img width="797" height="683" alt="image" src="https://github.com/user-attachments/assets/16760895-e5a0-4b63-9199-918e93c3f57f" />

## Changes

  - Remove obsolete NR_RESET_STRUCT_PAGE guidance from the MM folio prompt, since Linux removed it in c0b495b91a47.
  - Document that order-n compound pages naturally start at PFNs aligned to 1 << n, preventing reviews from flagging impossible unaligned compound-page head PFNs. 
  - Add a dedicated alignment.md subsystem guide covering:
      - ALIGN(), ALIGN_DOWN(), and IS_ALIGNED() semantics
      - PAGE_ALIGN() vs PFN/pageblock helpers
      - pageblock_align(), pageblock_start_pfn(), and pageblock_end_pfn() behavior
      - common review mistakes around inclusive/exclusive boundaries and raw order values
  - Register the new alignment guide in subsystem.md so it is loaded when patches touch alignment helpers.

## Motivation

LLM reviews can over-report issues when prompt guidance is stale or when helper semantics are easy to misread. These updates make the prompt set more precise, especially for MM and pageblock-related reviews, and should reduce false positives from incorrect alignment reasoning.

## Testing

In local testing, the updated guidance effectively reduced false positives caused by AI hallucinations or incorrect assumptions about alignment helper semantics.

