### PR TITLE
alignment: rewrite subsystem guidance around helper semantics

### DIFF
--- a/kernel/subsystem/alignment.md
+++ b/kernel/subsystem/alignment.md
@@ -1,27 +1,35 @@
 # Alignment Helpers
 
-## Generic ALIGN Semantics
+## Generic Alignment Semantics
 
-`ALIGN(x, a)` rounds `x` **up** to an `a` boundary. If `x` is already aligned,
-the result is `x`, not the next boundary. `ALIGN_DOWN(x, a)` rounds `x` **down**
-to an `a` boundary. `IS_ALIGNED(x, a)` tests whether `x` is already aligned.
+Misreading alignment helpers causes silent boundary bugs.
 
-The alignment argument `a` is expected to be a power-of-two value.
-
-For a half-open range `[start, end)`, use `ALIGN_DOWN(start, a)` and
-`ALIGN(end, a)` to cover the whole range. Use `ALIGN(start, a)` and
-`ALIGN_DOWN(end, a)` only when selecting fully-contained aligned chunks.
+- `ALIGN(x, a)` rounds `x` **up** to the first `a` boundary at or after `x`.
+  If `x` is already aligned, the result stays `x`.
+- `ALIGN_DOWN(x, a)` rounds `x` **down** to the containing `a` boundary.
+- `IS_ALIGNED(x, a)` tests whether `x` is already aligned to `a`.
+- The alignment argument `a` is expected to be a power of two.
+- See `include/linux/align.h` for these alignment helpers.
 
 ## Page Alignment Helpers
 
-`PAGE_ALIGN(addr)` is `ALIGN(addr, PAGE_SIZE)`. `PAGE_ALIGN_DOWN(addr)` is
-`ALIGN_DOWN(addr, PAGE_SIZE)`. `PAGE_ALIGNED(addr)` tests `PAGE_SIZE`
-alignment. These helpers operate on addresses, not PFNs.
+Mixing page helpers with PFNs, or pageblock helpers with byte addresses,
+silently computes wrong boundaries.
+
+- `PAGE_ALIGN(addr)` is `ALIGN(addr, PAGE_SIZE)`.
+- `PAGE_ALIGN_DOWN(addr)` is `ALIGN_DOWN(addr, PAGE_SIZE)`.
+- `PAGE_ALIGNED(addr)` checks `PAGE_SIZE` alignment.
+- These helpers operate on addresses, not PFNs.
+- These helpers can be verified in `include/linux/mm.h`.
 
 ## Pageblock Alignment Helpers
 
-`pageblock_nr_pages` is `1UL << pageblock_order`. Pageblock helpers operate on
-PFNs, not byte addresses:
+Confusing pageblock start, end, and upward rounding causes off-by-one
+pageblock errors.
+
+- `pageblock_nr_pages` is `1UL << pageblock_order`.
+- Pageblock helpers operate on PFNs, not byte addresses.
+- The core helpers are defined as:
 
 ```c
 #define pageblock_align(pfn)       ALIGN((pfn), pageblock_nr_pages)
@@ -30,36 +38,31 @@ PFNs, not byte addresses:
 #define pageblock_end_pfn(pfn)     ALIGN((pfn) + 1, pageblock_nr_pages)
 ```
 
-`pageblock_start_pfn(pfn)` returns the inclusive start PFN of the pageblock
-containing `pfn`. `pageblock_end_pfn(pfn)` returns the exclusive end PFN of the
-pageblock containing `pfn`; when `pfn` is itself pageblock-aligned, this is the
-next pageblock boundary, not `pfn`.
+- `pageblock_start_pfn(pfn)` returns the inclusive start PFN of the pageblock
+  containing `pfn`.
+- `pageblock_end_pfn(pfn)` returns the exclusive end PFN of the pageblock
+  containing `pfn`, i.e. the next boundary.
+- `pageblock_align(pfn)` rounds upward to the first pageblock boundary at or
+  after `pfn`; for an unaligned PFN it is therefore different from
+  `pageblock_start_pfn(pfn)`.
+- See `pageblock_order`, `pageblock_nr_pages`, and the helper macros in
+  `include/linux/pageblock-flags.h`.
 
-`pageblock_align(pfn)` rounds **up** to the first pageblock boundary at or after
-`pfn`. It is not equivalent to `pageblock_start_pfn(pfn)` for an unaligned PFN.
-
-Example with `pageblock_nr_pages == 1024`:
+Assume `pageblock_nr_pages == 512` for the numeric example below.
 
 | PFN | `pageblock_start_pfn()` | `pageblock_align()` | `pageblock_end_pfn()` |
 |-----|-------------------------|---------------------|-----------------------|
-| 2048 | 2048 | 2048 | 3072 |
-| 2049 | 2048 | 3072 | 3072 |
+| 512 | 512 | 512 | 1024 |
+| 513 | 512 | 1024 | 1024 |
 
-For a half-open PFN range `[start_pfn, end_pfn)`, align the covering range with
-`pageblock_start_pfn(start_pfn)` and `pageblock_end_pfn(end_pfn - 1)` when the
-range is non-empty.
+**REPORT as bugs**: treating `pageblock_end_pfn(pfn)` as inclusive, or using
+`pageblock_align(pfn)` where `pageblock_start_pfn(pfn)` is needed.
 
-## Common Review Mistakes
+## Quick Checks
 
-- Treating `ALIGN(x, a)` as strictly greater than `x`; it returns `x` when
-  already aligned.
-- Treating `ALIGN_DOWN(x, a)` as a no-op for unaligned values; it moves to the
-  previous boundary.
-- Passing an order where a size/count is required. Use `1UL << order`,
-  `PAGE_SIZE << order`, or `pageblock_nr_pages`, not raw `order`.
-- Confusing byte-address helpers (`PAGE_ALIGN()`) with PFN helpers
-  (`pageblock_*_pfn()`).
-- Treating `pageblock_end_pfn(pfn)` as inclusive. It is an exclusive end PFN.
-- Passing an exclusive range end directly to `pageblock_end_pfn()` when the
-  intended input is the last PFN in the range; use `end_pfn - 1` for non-empty
-  half-open ranges.
+- **Already-aligned input**: `ALIGN(x, a)` keeps an aligned `x` unchanged; it
+  does not mean "strictly next boundary".
+- **Unit mismatch**: `PAGE_*` helpers operate on addresses, while
+  `pageblock_*` helpers operate on PFNs.
+- **Exclusive end semantics**: `pageblock_end_pfn()` returns the boundary after
+  the containing pageblock.


### PR DESCRIPTION
Rework the alignment notes to follow the subsystem-template.md so the review points are easier to scan and apply. Highlight the helper semantics, unit expectations, and pageblock boundary rules that tend to cause review mistakes.