### PR TITLE
arm64, kvm-arm64, hyp-arm64: reviewer rules from live KVM/arm64 review

### DIFF
--- a/kernel/subsystem/arm64.md
+++ b/kernel/subsystem/arm64.md
@@ -78,6 +78,13 @@ safety semantics or causing unexpected traps.
       direct write of the same register, without the need for explicit
       synchronization." Recognize this class by that wording — do not assume
       every sysreg either always needs an `isb()` or never does.
+    - **`FPMR`** (FP8 mode register, `SYS_FPMR`): self-synchronizing at *register*
+      granularity — "a direct or indirect read of this register occurs in program
+      order relative to a direct write of this register without explicit
+      synchronization" (Arm ARM C5.2.9, Configuration). No `isb()` is needed
+      between an `FPMR` write and a following FP8 instruction. Its wording omits
+      the "appears"/"need for" phrasing of `ZCR/SMCR.LEN`, so match `FPMR` by name,
+      not by that exact pattern.
     - **`ICC_PMR_EL1`** (GIC priority mask, noted above): self-synchronizing by
       a separate guarantee in the GIC architecture, *not* by the sysreg wording
       above. After the write is architecturally executed, no interrupt below the
@@ -95,7 +102,7 @@ safety semantics or causing unexpected traps.
       a missing `pmr_sync()` on an unmask path, though still never a missing
       `isb()`.
   Flagging a missing `isb()` after a write to a self-synchronizing field (e.g.
-  `ZCR_ELx.LEN`) is a false positive.
+  `ZCR_ELx.LEN`) or register (e.g. `FPMR`) is a false positive.
 
 **REPORT as bugs:**
 - Writing to a control system register without an `isb()` as the very next

--- a/kernel/subsystem/arm64.md
+++ b/kernel/subsystem/arm64.md
@@ -65,6 +65,37 @@ safety semantics or causing unexpected traps.
       `GICR_ICENABLER0`, `GICR_CTLR.EnableLPIs` (1→0), and DPG writes.
       Priority, routing, and enable-set writes are NOT tracked by either RWP
       bit.
+- **Self-Synchronizing Registers and Fields (no ISB needed):** The blanket
+  rule above has architecturally-defined exceptions: some System register
+  effects are guaranteed visible to subsequent instructions in program order
+  *without* a CSE. The architecture grants this in more than one way, so
+  recognize both forms:
+    - **SVE/SME effective vector-length fields** (`ZCR_ELx.LEN`, and likewise
+      `SMCR_ELx.LEN`): a write takes effect for the following SVE/SME
+      instructions in program order with no intervening `isb()`. The ARM ARM
+      flags this in the field description with wording of the form "an indirect
+      read of `<REG>.<FIELD>` appears to occur in program order relative to a
+      direct write of the same register, without the need for explicit
+      synchronization." Recognize this class by that wording — do not assume
+      every sysreg either always needs an `isb()` or never does.
+    - **`ICC_PMR_EL1`** (GIC priority mask, noted above): self-synchronizing by
+      a separate guarantee in the GIC architecture, *not* by the sysreg wording
+      above. After the write is architecturally executed, no interrupt below the
+      new priority is taken, without requiring an `isb()` or exception boundary. Same
+      no-`isb()` outcome, different mechanism — so do not expect to find the
+      "indirect read ... in program order" wording on it. This no-`isb()`
+      guarantee is the *masking* direction (writing `ICC_PMR_EL1` to block
+      lower-priority interrupts, as on `local_irq_disable()`). The *unmasking*
+      direction (relaxing the mask to admit them again, as on
+      `local_irq_enable()`) does need a barrier — `pmr_sync()`, a `dsb` gated on
+      `ICC_CTLR_EL1.PMHE` (boot-time-patched to a nop when `PMHE == 0`, and
+      compiled out entirely without `CONFIG_ARM64_PSEUDO_NMI`), never an `isb()`.
+      So
+      do not read this as "`ICC_PMR_EL1` writes never need synchronization": flag
+      a missing `pmr_sync()` on an unmask path, though still never a missing
+      `isb()`.
+  Flagging a missing `isb()` after a write to a self-synchronizing field (e.g.
+  `ZCR_ELx.LEN`) is a false positive.
 
 **REPORT as bugs:**
 - Writing to a control system register without an `isb()` as the very next
@@ -84,6 +115,59 @@ safety semantics or causing unexpected traps.
   `isb()`.
 - Writing to tracked memory-mapped GIC registers without polling the
   appropriate `GICD_CTLR.RWP` or `GICR_CTLR.RWP`.
+
+## Auto-Generated Definitions and Semantic Drift
+
+Hardware definitions are increasingly moved from hand-rolled C macros to
+auto-generated infrastructure (e.g. the `.sysreg` files consumed by
+`gen-sysreg.awk`). The generator's contract is to reflect *global architectural
+truth*, not whatever software context the old C macros had baked in. A
+declarative change can therefore silently mutate the *value* of an
+auto-generated aggregate mask while leaving its *name* unchanged: the compiler
+stays silent, and standard CI stays silent because the build holds only the new
+snapshot, not the old one. Catching this is by design a code-review
+responsibility, not a tooling one.
+
+**Worked example.** `<REG>_RES1` is generated *only* from literal `Res1 N`
+lines in that register's `.sysreg` block (`gen-sysreg.awk`); it has no concept
+of features and defaults to `UL(0)` when the block declares no `Res1` bit. So a
+`.sysreg` edit that reclassifies a bit between `Res1 N` and `Field N` (or
+`Res0`) — adding a newly architected RES1 bit, or turning an existing RES1 bit
+into a writable field — silently changes the *value* of `<REG>_RES1` while its
+*name* stays put. `SCTLR_EL2_RES1` is a live consumer: today it expands to
+`UL(0)` and is OR'd into the EL2 SCTLR init values `INIT_SCTLR_EL2_MMU_ON` /
+`INIT_SCTLR_EL2_MMU_OFF` (`arch/arm64/include/asm/sysreg.h`). If a future
+`.sysreg` change added or dropped a `Res1` line in the `SCTLR_EL2` block, those
+init values would change with no edit at the consuming macro and no compiler or
+CI signal.
+
+Do not look to the generated mask for feature conditionality — it is not there.
+"RES1 only when a feature is absent" (e.g. `SCTLR_ELx.{EIS, EOS}` are RES1 when
+`FEAT_ExS` is unimplemented) lives in KVM's runtime feature map, tagged
+`AS_RES1` ("RES1 when not supported") in `arch/arm64/kvm/config.c`, not in
+`<REG>_RES1`. In `INIT_SCTLR_EL2_MMU_ON` above, `EIS`/`EOS` are forced to `1` by
+their own field macros (`SCTLR_ELx_EIS | SCTLR_ELx_EOS`), never by
+`SCTLR_EL2_RES1`.
+
+- **Trigger.** A patch touches a `.sysreg` file so as to allocate bits or
+  change a field's RES0 / RES1 classification, regenerating an aggregate
+  mask (`<REG>_RES0`, `<REG>_RES1`, and similar).
+- **Check.** Identify the auto-generated aggregate macros whose value the
+  change alters, then enumerate the C call-sites that consume those macros and
+  inspect each.
+- **Action.** Raise an Open Question / Tension asking the author to confirm the
+  consuming C does not rely on the *previous* semantic value of the mask — in
+  particular, code that ORs `<REG>_RES1` into an initial register value
+  expecting specific bits to be set.
+
+This generalizes beyond `.sysreg` to any auto-generated hardware-definition
+infrastructure where a declarative update silently changes
+the value of a consumed macro.
+
+**REPORT as a tension (Open Question):**
+- A `.sysreg` / declarative change that regenerates an aggregate mask consumed
+  by C initialization, without confirmation that the consumer is robust to the
+  mask's value changing.
 
 ## TLB Invalidation and Break-Before-Make (BBM)
 

--- a/kernel/subsystem/hyp-arm64.md
+++ b/kernel/subsystem/hyp-arm64.md
@@ -52,6 +52,35 @@ This test composes with the §`WARN_ON` Semantics correctness test, but does
 not replace it. Correctness ("is this assertion the right kind of check?") and
 severity ("if it triggers, is it a bug?") are independent axes.
 
+## EL2 Execution Context (nVHE/pKVM)
+
+At EL2 in nVHE/pKVM, a hypercall (or other trap) handler runs as a single
+**atomic, non-preemptible unit on the trapping CPU**, with physical interrupts
+masked, returning to EL1 via `eret` when done. The EL2 hyp is not the kernel:
+there is **no scheduler, no preemption, and none of the kernel-context
+deferred-work machinery** — no `sleep`/`schedule`, workqueues, softirqs, RCU
+callbacks, kthreads, `copy_{from,to}_user`, or `printk`/`pr_*`, and no mutexes
+or `irqsave` locks (interrupts are already masked; EL2 locking is
+`hyp_spin_lock`). A handler cannot be preempted part-way through and cannot hand
+work to a later context: whatever it does, it does synchronously before the
+`eret`.
+
+**Worked false-positive.** A finding of the form "this `READ_ONCE()` and the
+later `cmpxchg()` can race because the store becomes visible only after a
+*delayed* write" presumes the handler can be preempted, or its tail deferred,
+between the two. At EL2 nVHE there is no such local gap — the sequence runs to
+completion atomically on the trapping CPU.
+
+**Still in scope — cross-CPU concurrency.** This rule removes only the
+*local* preemption / deferral assumption. Genuine concurrency between two
+physical CPUs each running a handler against shared EL2 state is real and must
+still be reasoned about under the LKMM (memory ordering, cmpxchg visibility
+across CPUs). Do not let "EL2 is atomic" collapse into "EL2 is single-threaded."
+
+**Do NOT flag:**
+- Races or reorderings that require a single EL2 nVHE handler to be preempted,
+  or its work deferred to a later context, on the *same* CPU.
+
 ## Host De-Privilege Boundary (pKVM Lifecycle)
 
 In nVHE/pKVM, the host kernel boots at EL2 and *de-privileges itself* to EL1
@@ -67,7 +96,7 @@ install hyp text/data, populate per-CPU state, and finalize trap
 configuration; memory shared with future-EL2 is writable in place. After it
 (`pkvm_drop_host_privileges()` having run), the host is at EL1 and can only
 invoke EL2 via hypercalls; EL2-private memory becomes inaccessible (kmemleak
-excluded above).
+excluded below).
 
 **Markers a reviewer can grep for:**
 
@@ -96,6 +125,12 @@ excluded above).
     early via cpufeature detection (before any initcall runs) and is
     independent of de-privilege state. The privileged window is characterized
     by `is_protected_kvm_enabled() && !is_kvm_arm_initialised()`.
+*   **Hypercall ID band** decides a new hypercall's availability phase. A new
+    `enum __kvm_host_smccc_func` entry before `__KVM_HOST_SMCCC_FUNC_MIN_PKVM`
+    is init-only (gone once pKVM finalises); between `MIN_PKVM` and
+    `__KVM_HOST_SMCCC_FUNC_PKVM_ONLY` it is always-on; after `PKVM_ONLY` it is
+    pKVM-finalised-only. A new ID in the wrong band is reachable in the wrong
+    phase.
 
 **REPORT as bugs:**
 
@@ -141,6 +176,11 @@ from any host-controlled source.
 *   **Double-Fetch Risk:** Never dereference a host-provided pointer multiple
     times (double-fetch). Copy the necessary fields to EL2 private memory
     once.
+*   **Allocation Sources:** EL2 MUST NOT draw allocations from a free list or
+    memcache whose head pointer lives in host memory — the host can redirect
+    the allocation to an attacker-chosen physical address (TOCTOU). A
+    host-resident cache such as `stage2_teardown_mc` is a sink for host-bound
+    reclaim pages, never an allocation source.
 *   **VA Translation (`AT`):** To perform stage 1+2 translation of a Host VA,
     EL2 must use `AT S12E1R`. If translation fails, hardware reports the error
     in `PAR_EL1` (bit `.F = 1`).
@@ -239,6 +279,65 @@ are visible to EL2 leads to **State Desynchronization**.
     to EL2-private hyp structures (e.g., `pkvm_hyp_vcpu`) to remain visible
     across guest entries.
 
+## `kern_hyp_va` Idempotence and Pointer Provenance
+
+Misjudging when `kern_hyp_va()` transforms a pointer drives findings in both
+directions: a false "double `kern_hyp_va()` corrupts the pointer / faults" on a
+pointer it actually leaves unchanged, and a missed "defensive `kern_hyp_va()` on
+an already-hyp pointer" that genuinely mangles it. The discriminator is the
+pointer's provenance, and it is **not** whether the address is below
+`PAGE_OFFSET`.
+
+`kern_hyp_va()` converts a host kernel-linear (TTBR1) pointer to the EL2
+hyp-linear VA used to dereference host memory at EL2. It is a **mask-and-tag**
+operation (`__kern_hyp_va` in `arch/arm64/include/asm/kvm_mmu.h`; mask and tag
+computed in `arch/arm64/kvm/va_layout.c`): clear the high VA bits, then insert a
+single constant hyp tag. It has **no offset accumulation**, so it is idempotent
+on any pointer that *already carries the hyp tag*. Two classes do, and both are
+**below `PAGE_OFFSET`** yet still idempotent:
+
+- The hyp-linear image `kern_hyp_va()` itself produces — so a second application
+  is a no-op.
+- Every EL2 **linear-map** pointer: the hyp page allocator's output
+  (`hyp_phys_to_virt` / `hyp_page_to_virt`, `nvhe/memory.h`) and anything
+  reachable by `hyp_virt_to_phys` / `hyp_virt_to_page`. This covers the large
+  EL2-private objects — `pkvm_hyp_vm`, `pkvm_hyp_vcpu`, and the embedded
+  `hyp_vm->kvm` (see §State Divergence & Initialization Boundaries, "Hyp vs. Host
+  Back-Pointer").
+
+So the real split is **linear-map** (carries the tag → `kern_hyp_va` is a no-op)
+vs **private-VA-range** (no tag → mangled), not above/below `PAGE_OFFSET`.
+
+Idempotence does NOT extend to an EL2 **private-VA-range** pointer — the output
+of `pkvm_alloc_private_va_range` (`nvhe/mm.c`): `hyp_vmemmap`, the fixmap,
+ioremap/MMIO mappings, hyp stacks. These live outside the linear map and do not
+carry the hyp tag, so the mask relocates them and the *first* application
+corrupts the pointer.
+
+Severity of a genuinely mis-applied `kern_hyp_va()` depends on the target tree's
+`__kern_hyp_va()`. Upstream masks unconditionally, so a private-range input is
+corrupted. Android adds `if (!is_ttbr1_addr(v)) return v;` (a `>= PAGE_OFFSET`
+test), so there every already-hyp pointer short-circuits to a harmless no-op and
+only a genuine TTBR1 pointer is transformed. Check which form the tree carries
+before assigning severity.
+
+**Worked false-positive.** A pointer initialized as a hyp VA and later passed
+through `kern_hyp_va()` again is the recurring trap. `hyp_vcpu->vcpu.arch.sve_state`
+is set to a hyp VA in `pkvm_vcpu_init_sve()`, and `unpin_host_sve_state()` used
+to call `kern_hyp_va()` on it again; because that conversion is idempotent the
+call was redundant, not a bug, and upstream `02471a78a052b` removed it ("Since
+`kern_hyp_va()` is idempotent, it's not a bug"). The same holds for `kern_hyp_va(&hyp_vm->kvm)` or
+`kern_hyp_va(vcpu->kvm)` when `vcpu` is the hyp vCPU (`vcpu->kvm == &hyp_vm->kvm`,
+a linear-map object). Do not escalate any of these to memory corruption or a data
+abort; at most note the redundant call.
+
+**Do NOT flag:**
+- A redundant or double `kern_hyp_va()` on a linear-map pointer — a host
+  kernel-linear pointer, its hyp image, or any EL2 object reachable by
+  `hyp_virt_to_phys` / `hyp_virt_to_page` (e.g. `&hyp_vm->kvm`) — as corruption,
+  a fault, or any severity bug. It is a no-op; at most a cleanup note, since a
+  redundant `kern_hyp_va()` obscures the host→EL2 boundary each call site marks.
+
 ## EL2 Buddy Allocator (`hyp_pool`)
 
 EL2 uses a private buddy allocator (`struct hyp_pool` in
@@ -287,6 +386,22 @@ allocator):
     `-ENOMEM` is a normal runtime outcome.
 *   Allocating from one pool and freeing into another.
 
+## EL2 Transient Mappings (`hyp_fixmap`)
+
+To touch a host page outside the linear hyp map, EL2 uses `hyp_fixmap_map(phys)`
+/ `hyp_fixmap_unmap()` (`nvhe/mm.c`). The slot is **per-CPU**, the calls **must
+be paired**, and mappings **must not nest**: a path that fails to unmap on every
+exit holds the slot and corrupts the next user on that CPU, and a nested map
+clobbers the live slot. The unmap is also what performs the slot's TLB
+invalidation (the map does not), so a missed unmap leaves a stale valid TLB
+entry and the next map's freshly written PTE is bypassed: the new user reads or
+writes the previous mapping's physical page.
+
+**REPORT as bugs:**
+- A `hyp_fixmap_map()` whose error or early-exit paths do not all reach the
+  matching `hyp_fixmap_unmap()`.
+- A second `hyp_fixmap_map()` on a CPU before the first is unmapped.
+
 ## pKVM Page-Ownership Transitions
 
 pKVM tracks physical page ownership across three actors (host, hypervisor,
@@ -304,6 +419,11 @@ host.
 - **Atomicity of State Updates:** Ownership metadata and page-table entries
   for the affected range MUST be updated atomically from EL2's perspective.
   Partial updates observable to other CPUs create TOCTOU windows.
+- **Rollback Before Propagating Errors:** When EL2 mutates ownership metadata
+  (`hyp_vmemmap`, page state, refcounts) *before* calling a fallible primitive
+  (`kvm_pgtable_stage2_map`, `pkvm_create_mappings_locked`, …), the error path
+  MUST undo the mutation before returning. A bare `return err` after a partial
+  mutation leaves EL2 metadata inconsistent.
 - **Reclaim Path Discipline:** The reclaim path for a dying guest MUST
   enumerate pages by their recorded ownership state, not by the page-table
   walk. Pages already donated but whose metadata was not updated are otherwise
@@ -369,6 +489,140 @@ attack surface with a recurring pattern of missing range/offset checks.
   than EL2-private hyp state.
 - VCPU-load paths that do not refresh the hyp-side FGT register copy from the
   host VCPU.
+
+## Host-Owned vs Hyp-Owned `HCR_EL2` Bits (Protected vCPUs)
+
+For a protected vCPU, `HCR_EL2` is computed by the hyp at vCPU init from
+architectural and feature state (`pkvm_vcpu_reset_hcr()` seeds `HCR_GUEST_FLAGS`
+plus feature bits; `pvm_init_traps_hcr()` layers on the guest's trap
+configuration), *not* from the host. The host's `hcr_el2` value must never be
+allowed to define a protected guest's regime. But a small set of `HCR_EL2` bits
+are *host-owned runtime signals*, and those MUST flow from the host vCPU copy
+into the hyp vCPU on each load/entry (`handle___pkvm_vcpu_load`,
+`flush_hyp_vcpu`) and back on exit (`sync_hyp_vcpu`). The per-entry set is
+therefore an **allowlist**, and a reviewer must classify each `HCR_EL2` bit the
+code touches into one of two categories:
+
+- **Hyp-owned regime / configuration bits** define the guest's translation,
+  execution, and trap environment: e.g. `VM` (stage-2 enable), `RW`
+  (AArch64/AArch32 execution state), `TGE`, `IMO`/`FMO`/`AMO` (interrupt
+  routing), `TSC` (SMC trapping), `E2H`, and the `TID*`/`TACR` feature-trap
+  bits. These are fixed at hyp vCPU init. The host must never be able to set or
+  clear them for a protected guest.
+- **Host-owned runtime signals** are set/cleared dynamically by the host to
+  apply a benign policy or inject an event, and are meaningless unless they
+  reach the hyp vCPU that runs: `TWI`/`TWE` (WFI/WFE trapping policy) and `VSE`
+  (a pending *virtual SError* to deliver to the guest; under FEAT_RAS the host
+  also writes `VSESR_EL2` for the syndrome, then sets `VSE` to make it pending).
+  The virtual IRQ/FIQ pending bits (`VI`/`VF`) are architecturally the same
+  class of injection signal, but are not part of this allowlist: KVM delivers
+  guest interrupts through the vGIC, not via these `HCR_EL2` bits.
+
+Because the per-entry set is an allowlist, **both directions are bugs**:
+
+- **Over-inclusion (security):** sourcing a regime/configuration bit from the
+  host into a protected hyp vCPU lets the host reconfigure the guest's
+  trap/execution environment.
+- **Under-inclusion (function):** dropping a host-owned signal from the
+  allowlist means the host can no longer reach the guest with it. Canonical
+  case: `flush_hyp_vcpu()` masked the host's `hcr_el2` down to
+  `HCR_TWI | HCR_TWE`, which silently dropped `HCR_VSE`, so a host-injected (and
+  deferred/masked) virtual SError was never delivered to a pKVM guest. The
+  confinement that caused this was introduced by `b56680de9c648` ("KVM: arm64:
+  Initialize trap register values in hyp in pKVM"); the fix restores `HCR_VSE`
+  to the flowed set. A new per-entry mask that omits a legitimate host-owned
+  signal is this bug.
+
+**REPORT as bugs:**
+- A protected-vCPU load/entry path that sources any `HCR_EL2` bit *other than* a
+  host-owned signal (i.e. a regime/configuration bit) from the host.
+- A per-entry `HCR_EL2` allowlist that omits a host-owned injection signal the
+  host relies on (e.g. `HCR_VSE` for virtual SError delivery), so the event
+  never reaches the guest.
+
+**Do NOT flag:**
+- The per-entry path flowing only the allowlisted host-owned bits
+  (`HCR_TWI`/`HCR_TWE`/`HCR_VSE`) while leaving every other `HCR_EL2` bit at its
+  hyp-init value. That confinement is correct, not a "partial HCR sync."
+
+## FPSIMD / SVE Save Regime (pKVM Mode vs Standard nVHE)
+
+EL2 switches FPSIMD/SVE/SME state lazily: the first guest access to FP/SIMD/SVE
+traps to `kvm_hyp_handle_fpsimd()` (`hyp/switch.h`), which deactivates the
+relevant CPTR traps, saves the live host context, and restores the guest
+context. How the *host's* state is preserved diverges by **KVM mode** — whether
+pKVM is enabled (`is_protected_kvm_enabled()`), NOT by whether the individual
+guest is a protected pVM — and under pKVM that divergence is a confidentiality
+invariant, not a performance tweak:
+
+- **pKVM enabled (`is_protected_kvm_enabled()`):** the trap handler eagerly
+  saves the host's FP/SVE state *in the hyp*, gated on
+  `is_protected_kvm_enabled() && host_owns_fp_regs()`
+  (`kvm_hyp_save_fpsimd_host()`). The gate is the global mode, so this applies
+  to **every** guest the hyp runs — protected pVMs and non-protected guests
+  alike (all of which take the `is_protected_kvm_enabled()` branch of
+  `handle___kvm_vcpu_run`, i.e. `flush_hyp_vcpu` / `sync_hyp_vcpu`). The hyp
+  owns host-state save/restore here "as not to reveal that fpsimd was used by a
+  guest nor leak upper sve bits": the host must not be able to infer a guest
+  touched FP, and stale host SVE register bits must never be visible to the
+  guest. The host SVE state is saved at the *host's* max VL
+  (`kvm_host_sve_max_vl`), not the guest's.
+- **Standard nVHE (pKVM disabled):** the hyp does NOT eagerly save host FP
+  state. The host is fully trusted and its vCPU is run directly; its own
+  lazy-FPSIMD machinery restores host state after the run, and the hyp only
+  marshals vector length around entry/exit via `fpsimd_lazy_switch_to_guest()` /
+  `fpsimd_lazy_switch_to_host()` (which move `ZCR_EL1` / `ZCR_EL2`), wrapped
+  around `__kvm_vcpu_run()`. These lazy-switch helpers are NOT used under pKVM.
+
+New or modified EL2 FP-trap / FP-switch code must respect this split.
+
+**REPORT as bugs:**
+- Under pKVM, an FP path that restores (or exposes) guest FP without first
+  ensuring the hyp has saved and scrubbed the host's live FP/SVE state. This
+  leaks host register contents, including SVE upper bits, into the guest.
+- Saving *host* FP/SVE state at the guest's VL (or any VL narrower than the
+  host max), which truncates the host's registers.
+- FP-trap code that keys the eager-save decision off the per-guest protected
+  flag instead of `is_protected_kvm_enabled()`, or that assumes the
+  `fpsimd_lazy_switch_to_*` path runs under pKVM.
+
+**Do NOT flag:**
+- The absence of an eager `kvm_hyp_save_fpsimd_host()` on the standard-nVHE
+  (pKVM-disabled) path. There the trusted host's own lazy restore handles it; a
+  hyp-side eager save is not required and is not a "missing save."
+- The eager host-save running for a *non-protected* guest under pKVM. The gate
+  is the global mode, so this is correct, not redundant or misapplied work.
+
+## Per-Load vs Per-Entry Synchronization Seams (pKVM Lifecycle)
+
+When a guideline or commit message says some state "MUST be synced," the *seam*
+it names is part of the requirement. pKVM has two synchronization points with
+very different cadence, and a "missing sync" finding is valid only when the
+check is applied at the seam the requirement actually names.
+
+| Seam | Function(s) | Cadence | Handles |
+| :--- | :--- | :--- | :--- |
+| **Per-load** | `handle___pkvm_vcpu_load` (calls `pkvm_load_hyp_vcpu`) | Once, when the host's `KVM_RUN` loads a vCPU onto a physical CPU | Coarse configuration that persists across many entries (e.g. the `arch.fgt` block copy for non-protected guests) |
+| **Per-entry** | `flush_hyp_vcpu` (and the matching `sync_hyp_vcpu` on exit) | Every guest re-entry — potentially thousands of times between loads | Fine-grained per-entry state churn (e.g. `hcr_el2`, `mdcr_el2`, `arch.iflags`) |
+
+Before flagging a "missing sync," quote the guideline's *exact* cadence word —
+"on each vCPU **load**" vs "on each **entry**" / "**run**" — and confirm the
+check is against the matching function. A copy the requirement places at vCPU
+load is satisfied even when it is absent from the per-entry path, and vice
+versa.
+
+**Worked false-positive.** FGT trap registers are required to be copied "on
+each vCPU load" (see §Trap Register Initialization). That copy lives in
+`handle___pkvm_vcpu_load`, whose non-protected `else` branch copies the whole
+`arch.fgt` block from `host_vcpu` into the hyp vCPU. Flagging `flush_hyp_vcpu`
+(the per-entry path) for "not syncing `arch.fgt`" is a false positive: it is
+the wrong seam. The per-entry path correctly syncs only per-entry state; the
+per-load FGT copy is not its responsibility.
+
+**Do NOT flag:**
+- Per-load state (the FGT block, etc.) "missing" from the per-entry path
+  (`flush_hyp_vcpu` / `sync_hyp_vcpu`) when it is correctly handled at vCPU
+  load.
 
 ## SMC imm16 / SMCCC Pass-Through Rules
 

--- a/kernel/subsystem/hyp-arm64.md
+++ b/kernel/subsystem/hyp-arm64.md
@@ -123,8 +123,14 @@ excluded below).
 *   `is_protected_kvm_enabled()` (`arch/arm64/include/asm/virt.h`) is the
     canonical predicate for "pKVM mode is configured." It becomes true very
     early via cpufeature detection (before any initcall runs) and is
-    independent of de-privilege state. The privileged window is characterized
-    by `is_protected_kvm_enabled() && !is_kvm_arm_initialised()`.
+    independent of de-privilege state — so on its own it does *not* tell you
+    whether the privileged window is still open. The discriminator the
+    hypervisor actually uses is the `kvm_protected_mode_initialized` static key
+    (read host-side via `is_pkvm_initialized()`), enabled during pKVM
+    finalisation (`arch/arm64/kvm/pkvm.c`): while it is off the early
+    "privileged" hypercalls are reachable, and `handle_host_hcall`
+    (`arch/arm64/kvm/hyp/nvhe/hyp-main.c`) selects the init-only / always-on /
+    finalised-only hcall bands off exactly that branch.
 *   **Hypercall ID band** decides a new hypercall's availability phase. A new
     `enum __kvm_host_smccc_func` entry before `__KVM_HOST_SMCCC_FUNC_MIN_PKVM`
     is init-only (gone once pKVM finalises); between `MIN_PKVM` and

--- a/kernel/subsystem/kvm-arm64.md
+++ b/kernel/subsystem/kvm-arm64.md
@@ -147,6 +147,18 @@ access patterns.
     guest misconfiguration. Every new field exposure must be paired with the
     correct `kvm_id_reg_rw_mask` or RESx-handling entry and a corresponding
     trap/enablement in `HCR_EL2`, `CPTR_EL2`, or `MDCR_EL2`.
+*   **`vcpu_sysreg` numbering is sparse — never range-check it:** `enum
+    vcpu_sysreg` (`arch/arm64/include/asm/kvm_host.h`) indexes
+    `vcpu->arch.ctxt.sys_regs[]`, but VNCR-mapped entries are numbered by their
+    VNCR-page byte offset (`VNCR(r)` = `__VNCR_START__ + VNCR_r / 8`), not in
+    declaration order. Selecting or skipping registers by a numeric value range
+    over the enum covers unintended registers: a loop meaning "skip the timer
+    block" written as `if (i >= CNTVOFF_EL2 && i <= CNTP_CTL_EL0) continue;` also
+    skips `SCTLR_EL1` / `TCR_EL1` / `MAIR_EL1` / … whose offsets fall in that byte
+    span, silently dropping guest state (a guest that reprograms its own EL1 regs
+    still boots, but the host's `GET/SET_ONE_REG` view desyncs). Flag any numeric
+    range or `<` / `>` comparison over `enum vcpu_sysreg` values; require an
+    explicit per-register allowlist.
 
 ## VGIC LPI and vLPI Invariants
 


### PR DESCRIPTION
## Summary

Five commits extending the arm64, host-side KVM/arm64, and EL2/hyp (pKVM)
reviewer guides with rules learned from real review traffic, across three guide
files:

- `arm64:` self-synchronizing system registers (incl. FPMR), and auto-generated
  sysreg mask drift.
- `kvm-arm64:` the sparse `vcpu_sysreg` enum (a numeric range over it silently
  spans unintended registers).
- `hyp-arm64:` the EL2 execution-context model plus a set of pKVM lifecycle and
  state invariants, and a correction to the de-privilege window predicate.

Almost entirely additive (+366 / -3). No existing rule is removed (the
deletions are reworked wording, including a stale back-reference fix).

## Motivation

Sashiko (sashiko.dev) has been running the updated KVM/arm64 prompts in live
review for about a week. The arm64 maintainers have noticed the difference and
are happy with the result. That week of real use, together with additional
local testing of the prompts, also surfaced a handful of false positives,
misses, and sharper framings worth folding back upstream.

Every rule here is dual-mode: it states what to FLAG and, just as importantly,
what NOT to flag. Suppressing confident false positives is half the value of a
review prompt, so several of these exist specifically to stop the reviewer
mis-flagging a correct pattern.

## arm64.md

- **Self-synchronizing registers (false-positive fix).** Not every system
  register write needs an ISB. `ZCR_ELx.LEN` and `SMCR_ELx.LEN` take effect for
  subsequent SVE/SME instructions in program order with no context
  synchronization event, per the Arm ARM LEN field wording ("an indirect read
  ... appears to occur in program order relative to a direct write ... without
  the need for explicit synchronization"). The rule teaches the reviewer to
  recognize that self-synchronizing class by its wording. Origin: Sashiko was
  repeatedly flagging `ZCR_ELx` writes as missing an `isb()`.

- **FPMR self-synchronizing (false-positive fix).** `FPMR` joins the
  self-synchronizing set: "a direct or indirect read of this register occurs in
  program order relative to a direct write of this register without explicit
  synchronization" (Arm ARM C5.2.9). No `isb()` is needed after an `FPMR` write.
  Its wording is register-granularity and differs slightly from the
  `ZCR/SMCR.LEN` form, so it is enumerated by name rather than by that exact
  phrasing.

- **Auto-generated sysreg mask drift.** `<REG>_RES1` is generated purely from
  literal `Res1 N` lines in the `.sysreg` block, so reclassifying a bit between
  `Res1` and a `Field` silently changes the mask's value while its name stays
  put. Code that ORs such a mask into a register init value (e.g.
  `SCTLR_EL2_RES1` in `INIT_SCTLR_EL2_MMU_ON`) then forces a different bit set,
  with no compiler or CI signal. Surfaced as a review tension, generalized
  beyond `.sysreg`.

## kvm-arm64.md

- **Sparse `vcpu_sysreg` enum (miss-prevention, narrow trigger).** Most of this
  series suppresses false positives; this rule is the exception that asks the
  reviewer to catch something, and it is deliberately narrow and mechanically
  checkable so it should not add noise. It earns its place by having caught a
  real, silent bug in live review: code that meant "skip the 5 timer registers"
  expressed it as a numeric range, `if (i >= CNTVOFF_EL2 && i <= CNTP_CTL_EL0)`,
  which also dropped about a dozen EL1 sysregs (`SCTLR_EL1`, `TCR_EL1`,
  `MAIR_EL1`, ...) from the host's view of guest state. `enum vcpu_sysreg`
  numbers its VNCR-mapped entries by VNCR page byte offset (`VNCR(r)` =
  `__VNCR_START__ + VNCR_r / 8`), not sequentially, so a numeric range over the
  enum silently spans unintended registers. The rule flags a numeric range or
  comparison over `enum vcpu_sysreg` values (a concrete code shape, not a
  judgement call) and asks for an explicit per-register allowlist.

## hyp-arm64.md

- **EL2 execution context.** nVHE/pKVM trap handlers run atomic and
  non-preemptible on the trapping CPU with no deferred-work machinery (no
  scheduler, workqueues, softirqs, RCU, kthreads, copy_*_user, printk, mutexes).
  Findings that assume local preemption or deferral are false positives.
  Cross-CPU concurrency stays in scope.

- **Per-load vs per-entry sync seams.** A "missing sync" is valid only at the
  seam the requirement names (vCPU load vs guest entry). FGT worked example.

- **kern_hyp_va() idempotence and pointer provenance (false-positive fix).**
  kern_hyp_va() is mask-and-tag with no offset accumulation, so it is idempotent
  on any pointer already carrying the hyp tag, including every EL2 linear-map
  pointer (the hyp page allocator's output, for example `&hyp_vm->kvm`), all of
  which sit below PAGE_OFFSET. So below-PAGE_OFFSET is NOT the discriminator:
  linear-map (carries the tag, a no-op) vs the EL2 private VA range (no tag) is.
  A redundant or double kern_hyp_va() on a linear-map pointer is a no-op, never
  corruption or a fault, so do not flag it. The one class the mask does mangle
  is a `pkvm_alloc_private_va_range` pointer (`hyp_vmemmap`/fixmap/ioremap/stack),
  left as a factual caveat. Severity on a genuinely mis-applied call depends on
  the target tree (unconditional mask vs an `is_ttbr1_addr()` guard). Origin:
  Sashiko (and a stale line in our own dev doc) flagged `kern_hyp_va(&hyp_vm->kvm)`
  as "corrupts the pointer", which is the exact false positive this suppresses.

- **EL2 transient mappings (hyp_fixmap).** map/unmap must be paired per-CPU and
  must not nest. The unmap carries the slot's TLB invalidation, so a missed
  unmap leaves a stale entry for the next user on that CPU.

- **Hypercall ID band.** Placement in `__kvm_host_smccc_func` decides
  availability across the de-privilege boundary (init-only, always-on,
  pKVM-finalised-only).

- **Allocation sources (TOCTOU).** EL2 must not allocate from a free list whose
  head lives in host memory.

- **Rollback before propagating errors.** Undo EL2 metadata mutations on a
  fallible-primitive error path.

- **FPSIMD/SVE save regime.** The eager hyp-side host FP/SVE save is gated on
  pKVM mode (`is_protected_kvm_enabled()`), not on whether the individual guest
  is protected. Under pKVM it applies to every guest (a confidentiality
  invariant), while standard nVHE relies on the trusted host's lazy restore. FP
  code keyed off the per-guest protected flag instead of the mode is a bug.

- **Host-owned vs hyp-owned HCR_EL2 bits.** For protected vCPUs HCR_EL2 is
  computed by the hyp at vCPU init; the per-entry set of host-sourced bits is an
  allowlist of host-owned runtime signals (TWI/TWE WFx policy, VSE virtual
  SError). Dual-mode in both directions: flag a regime/config bit sourced from
  the host (security), and flag a host-owned signal dropped from the allowlist
  (function, for example the HCR_VSE virtual-SError-delivery case).

- **De-privilege window predicate (accuracy fix).** Corrects a pre-existing
  context line: the pKVM "privileged window" (where init-only hypercalls are
  reachable) is gated by the `kvm_protected_mode_initialized` static key
  (`is_pkvm_initialized()`), checked in `handle_host_hcall`, not by
  `is_protected_kvm_enabled() && !is_kvm_arm_initialised()`. Kept as its own
  commit so it can be taken or dropped independently.

## Commits

- `arm64: add self-synchronizing register and sysreg mask drift rules`
- `hyp-arm64: add EL2 execution-context and pKVM lifecycle review rules`
- `kvm-arm64: flag numeric range checks over the sparse vcpu_sysreg enum`
- `arm64: note FPMR in the self-synchronizing register list`
- `hyp-arm64: correct the de-privilege privileged-window predicate`
