### PR TITLE
kernel: Filter automated review feedback

### DIFF
--- a/kernel/agent/lore.md
+++ b/kernel/agent/lore.md
@@ -15,7 +15,7 @@ about a kernel patch and identifies unaddressed review comments.
 **IMPORTANT**: This agent searches ONLY for discussion related to THIS SPECIFIC
 PATCH. We are looking for:
 - Prior versions of this exact patch (v1, v2, v3, etc.)
-- Review comments on those prior versions
+- Human review comments on those prior versions
 - Author responses to review feedback
 
 We are NOT looking for:
@@ -31,6 +31,37 @@ We are NOT looking for:
 Only use `lore_search` with `subject_patterns` for exact subject matching.
 
 The goal is to find unaddressed review comments from prior versions of this patch.
+
+## Automated Review Quarantine
+
+Automated reviews and bot mail are NOT review evidence. They must never become
+`LORE-*` issues, and they must never be quoted or cited in review output.
+
+Treat a reply as quarantined bot feedback if the sender, subject, body, links,
+or signature indicates automation. This includes:
+- senders or names containing `bot`, `robot`, `kbuild`, `kernel test`,
+  `syzbot`, `sashiko`, `claude`, `bpf-ci`, or obvious CI
+  automation names
+- addresses such as `sashiko-bot@kernel.org`, `bot+bpf-ci@kernel.org`, or
+  `kernel-patches-review-bot`
+- phrases such as `AI review found`, `AI reviewed your patch`,
+  `Sashiko AI review`, `BPF CI`, `CI run summary`, or `This concern was
+  raised by`
+- links to automated review systems such as `sashiko.dev`,
+  `netdev-ai.bots.linux.dev`, GitHub Actions runs, or kernel-patches CI output
+
+Also quarantine human replies that only quote, forward, summarize, or ask about
+automated review feedback without adding an independent human technical
+analysis. If a human reply contains both bot-quoted text and independent human
+analysis, ignore the bot-quoted portion and use only the independent human
+analysis.
+
+For each quarantined automated comment, add a compact entry to
+`ignored_bot_comments` in `LORE-result.json`. Include enough matching data for
+the report agent to suppress duplicated findings later: message ID, sender,
+bot name if identifiable, subject, date, affected files/functions/symbols if
+mentioned, and a short technical summary. Do not add quarantined comments to
+`issues` or `all-comments`.
 
 ## Input
 
@@ -86,16 +117,20 @@ For each message ID found in Step 2.1, use `lore_search` with:
 ### Step 2.3: Read replies for review comments
 
 For each reply from Step 2.2:
-1. Identify if it's a review comment (vs. test robot, ACK, or author response)
-2. Extract technical concerns, bugs, design issues
-3. Check if author responded to the concern
-4. Note if concern was addressed in later versions
+1. Apply the Automated Review Quarantine first.
+2. If quarantined, add it to `ignored_bot_comments` and do not process it as a
+   review comment.
+3. Otherwise, identify if it's a human review comment (vs. ACK or author
+   response).
+4. Extract technical concerns, bugs, design issues.
+5. Check if author responded to the concern.
+6. Note if concern was addressed in later versions.
 
 ---
 
 ## Step 3: Categorize Review Comments
 
-For each review comment found in Step 2.3, categorize as:
+For each non-quarantined human review comment found in Step 2.3, categorize as:
 - **Technical concerns**: Bugs, race conditions, resource leaks, crashes
 - **Design feedback**: Architectural suggestions, alternative approaches
 - **Style/nits**: Formatting, naming, minor improvements
@@ -103,6 +138,8 @@ For each review comment found in Step 2.3, categorize as:
 - **Acks/Reviews**: Positive acknowledgments (Reviewed-by, Acked-by)
 
 Focus on **technical concerns** - these are most likely to be unaddressed issues.
+Do not categorize quarantined automated feedback as technical concerns,
+questions, or review comments.
 
 ---
 
@@ -146,7 +183,8 @@ Only flag comments that:
 **ALWAYS** write `./review-context/LORE-result.json`, even when no issues were
 found.  The orchestrator requires this file to confirm the agent completed
 successfully.  When no issues exist, use `"issues": []` and
-`"unaddressed-count": 0`.
+`"unaddressed-count": 0`. Always include `ignored_bot_comments`, using an empty
+array when no automated comments were found.
 
 ```json
 {
@@ -155,6 +193,20 @@ successfully.  When no issues exist, use `"issues": []` and
   "versions-found": ["v1", "v2", "v3"],
   "total-comments-reviewed": M,
   "unaddressed-count": K,
+  "ignored_bot_comments": [
+    {
+      "message-id": "<id>",
+      "sender": "<name or email>",
+      "bot-name": "<sashiko|bpf-ci|claude|other>",
+      "subject": "<subject>",
+      "date": "<date>",
+      "url": "https://lore.kernel.org/...",
+      "affected_files": ["path/to/file.c"],
+      "affected_functions": ["function_name"],
+      "affected_symbols": ["symbol_name"],
+      "summary": "<brief technical summary of quarantined bot feedback>"
+    }
+  ],
   "issues": [
     {
       "id": "LORE-1",
@@ -203,10 +255,13 @@ successfully.  When no issues exist, use `"issues": []` and
 | `issue_context` | 3 lines from current code at the issue location (empty array if unknown) |
 | `issue_description` | Summary including reviewer name, version, and concern |
 | `lore_reference` | Lore-specific metadata for linking to original discussion |
+| `total-comments-reviewed` | Count only non-quarantined human comments |
+| `ignored_bot_comments` | Quarantined automated feedback, never review issues |
 
 **DO NOT**:
 - Read or modify FILE-N-review-result.json files
 - Create lore-summary.json (replaced by LORE-result.json)
+- Emit quarantined automated feedback as `LORE-*` issues
 
 ---
 
@@ -219,6 +274,7 @@ Threads searched: <count>
 Versions found: <list>
 Comments reviewed: <count>
 Unaddressed comments: <count>
+Ignored automated comments: <count>
 
 Output file: ./review-context/LORE-result.json
 ```

--- a/kernel/agent/report.md
+++ b/kernel/agent/report.md
@@ -32,7 +32,8 @@ Add each of the following to TodoWrite:
 
 - `./review-context/index.json` - list of files and changes analyzed
 - `./review-context/commit-message.json` - commit metadata (author, subject, SHA)
-- `./review-context/LORE-result.json` - lore issues (may not exist if agent was skipped)
+- `./review-context/LORE-result.json` - lore issues and ignored bot comments
+  (may not exist if agent was skipped)
 - `./review-context/SYZKALLER-result.json` - syzkaller claim verification (may not exist if not a syzkaller commit)
 - `./review-context/FIXES-result.json` - fixes tag issue (may not exist if agent was skipped)
 - `<prompt_dir>/inline-template.md` - formatting template
@@ -74,6 +75,8 @@ From the files already loaded in Step 1:
 1. If `LORE-result.json` was loaded, collect issues from the `issues` array
 2. Each lore issue has id like "LORE-1", "LORE-2", etc.
 3. If file was NOT found: lore checking was skipped or found no issues
+4. Also collect `ignored_bot_comments`. These are quarantined automated review
+   comments and must be used only for suppression, never as report evidence.
 
 **Syzkaller verification** (from SYZKALLER-result.json):
 1. If `SYZKALLER-result.json` was loaded, extract the verification summary
@@ -90,13 +93,51 @@ From the files already loaded in Step 1:
 - Syzkaller issues: id pattern "SYZKALLER-1", etc
 - Fixes issues: id pattern "FIXES-1", etc
 
+### Automated Review Suppression
+
+Before counting or rendering issues, filter the combined issue list against
+automated review evidence.
+
+Forbidden bot evidence includes these case-insensitive strings and patterns:
+- `sashiko`, `sashiko-bot`, `sashiko.dev`
+- `bot+bpf-ci`, `bpf-ci`, `kernel-patches-review-bot`, `kernel-patches CI`
+- `claude`, `AI review found`, `AI reviewed your patch`
+- `CI run summary`, `netdev-ai.bots.linux.dev`
+- any reviewer/sender field containing `bot` or `robot`
+
+Drop an issue completely if any issue field, lore reference, description,
+context, guide text, source, recommendation, or rendered draft text cites or
+quotes forbidden bot evidence. Never rewrite these citations into neutral
+language; the issue must be omitted.
+
+Also drop an issue if it materially overlaps any `ignored_bot_comments` entry
+from `LORE-result.json`. Treat overlap as present if any of these match:
+- same file path or basename plus same function or symbol
+- same quoted code line, helper name, struct field, enum value, map name, test
+  name, or commit-message phrase
+- same technical topic in the bot summary, even if wording differs
+- same issue category and same affected subsystem when the bot summary is
+  specific enough to identify the concern
+
+Bias toward suppression. If it is plausible that the issue repeats earlier bot
+feedback, drop it. This applies to `FILE-*`, `LORE-*`, `FIXES-*`, and any
+other issue source. Remaining issues must be supported by source-code,
+commit-message, or human-review evidence without mentioning the bot feedback.
+
+Do not count dropped issues in:
+- total issues
+- guide-flagged issues
+- highest severity
+- `review-inline.txt`
+- `review-metadata.json`
+
 **Issue types**: Each issue may have an `issue_type` field:
 - `"regression"` (default if field is absent): confirmed bug with proof
 - `"potential-issue"`: guide-directive flagged pattern where the agent is
   uncertain. These have additional `guide_directive` and `agent_analysis` fields
   documenting both perspectives.
 
-Track totals:
+Track totals after Automated Review Suppression:
    - Total issues found (regressions + guide-flagged), including lore and syzkaller
    - Guide-flagged issues count (issue_type = "potential-issue")
    - Highest severity level
@@ -152,6 +193,26 @@ be sent when inline-template.md is run later.
   }
 }
 ```
+
+**Ignored bot comment format** (from LORE-result.json):
+
+```json
+{
+  "message-id": "<id>",
+  "sender": "<name or email>",
+  "bot-name": "<sashiko|bpf-ci|claude|other>",
+  "subject": "<subject>",
+  "date": "<date>",
+  "url": "https://lore.kernel.org/...",
+  "affected_files": ["path/to/file.c"],
+  "affected_functions": ["function_name"],
+  "affected_symbols": ["symbol_name"],
+  "summary": "<brief technical summary of quarantined bot feedback>"
+}
+```
+
+These entries are only suppression fingerprints. Do not quote them, summarize
+them, or cite them in `review-inline.txt`.
 
 **Syzkaller verification format** (from SYZKALLER-result.json):
 
@@ -230,8 +291,9 @@ phrasing like "A subsystem pattern flags this as potentially concerning:" rather
 than asserting a definite bug.
 
 **Note**: you must send EVERY issue described in the FOO-result.json files.
-The decisions about filtering issues happened in other prompts, your one and
-only job is to format those issues.
+Except for the Automated Review Suppression above, the decisions about
+filtering issues happened in other prompts, and your job is to format the
+remaining issues.
 
 **Commit-message issues**: Treat any issue with `file_name: "COMMIT_MESSAGE"`
 or an issue source that points at the commit message as a commit-message issue,
@@ -279,6 +341,8 @@ Create `<output_dir>/review-metadata.json` with the following exact format:
    - Contains no ALL CAPS headers
    - Uses proper quoting with > prefix
    - Has professional tone
+   - Does not mention or cite forbidden bot evidence from Automated Review
+     Suppression. If it does, remove the entire issue and regenerate the file.
 
 2. Verify `<output_dir>/review-metadata.json` exists and:
    - Has all required fields
@@ -304,6 +368,7 @@ Lore context (from LORE-result.json):
 - Threads found: <count or "not checked">
 - Versions found: <list or "n/a">
 - Unaddressed comments: <count>
+- Ignored automated comments: <count>
 
 Syzkaller verification (from SYZKALLER-result.json):
 - Total claims verified: <count or "not a syzkaller commit">

--- a/kernel/inline-template.md
+++ b/kernel/inline-template.md
@@ -8,6 +8,17 @@ any summary, comments or questions you add should be wrapped at 78 characters
 
 - Never include bugs filtered out as false positives in the report
 
+- Never include, quote, cite, summarize, or refer to automated reviews or bot
+  comments. Case-insensitively, the final report must not mention Sashiko, sashiko-bot,
+  sashiko.dev, BPF CI prior reviews, bot+bpf-ci, kernel-patches-review-bot,
+  Claude, AI review output, GitHub Actions CI run summaries, or any other bot
+  as evidence for an issue.
+
+- If an issue depends on, overlaps, or repeats automated review feedback, omit
+  the entire issue. Do not rewrite "Sashiko found this" into neutral wording.
+  Only report issues supported independently by source code, commit messages,
+  or non-bot human review comments.
+
 - Always end the report with a blank line.
 
 - The report must be conversational with undramatic wording, fit for sending
@@ -43,8 +54,9 @@ the author.
   but should be reworded to fit the template requirements.
 
 - You MUST include every issue sent, even if the additional details explain the
-  issue was fixed in a later commit.  Your job is to format issues, not decide
-  which ones are worth including.
+  issue was fixed in a later commit. The only exception is automated review
+  suppression: if an issue contains or repeats bot review evidence, omit the
+  entire issue.
 
 - Do not add additional explanatory content about why something matters or what
   benefits it provides. State the issue and the suggestion, nothing more.
@@ -263,6 +275,12 @@ Create a TodoWrite for these items, all of which your report should include:
   in the diff that introduced them.  Do not put the quoting '> ' characters in
   front of your new text.
 - [ ] Place your questions as close as possible to the buggy section of code.
+- [ ] Search the final report case-insensitively for forbidden automated review evidence:
+      `sashiko`, `sashiko.dev`, `bot+bpf-ci`, `kernel-patches-review-bot`,
+      `Claude`, `AI review found`, `AI reviewed your patch`, `CI run summary`,
+      and `netdev-ai.bots.linux.dev`. If any appear outside quoted commit text
+      that is itself being reviewed as a commit-message issue, remove the entire
+      affected issue and regenerate the report.
 - [ ] Snip portions of the quoted content unrelated to your review
   - [ ] Create a TodoWrite with every hunk in the diff.  Check every hunk
         to see if it is relevant to the review comments.

--- a/kernel/lore-thread.md
+++ b/kernel/lore-thread.md
@@ -14,6 +14,25 @@ The output of this patch review will be used by maintainers when deciding if a
 given patch is ready to include.  It's important that we make sure
 all email comments on the patches are addressed, especially those from maintainers.
 
+## Automated Review Quarantine
+
+Automated reviews and bot mail are not review comments for this prompt. Never
+quote, cite, summarize, or report issues from Sashiko, prior BPF CI/Claude
+reviews, CI bots, test robots, or any sender that appears automated.
+
+Quarantine a message if the sender, subject, body, link, or signature includes
+signals such as `bot`, `robot`, `sashiko`, `claude`, `bpf-ci`,
+`AI review found`, `AI reviewed your patch`, `CI run summary`, `sashiko.dev`,
+or `netdev-ai.bots.linux.dev`.
+
+Also quarantine human replies that only forward, quote, or ask about automated
+review feedback without adding independent human technical analysis. If a
+human reply contains both bot-quoted text and independent human analysis,
+ignore the bot-quoted portion and process only the independent human analysis.
+
+If a potential issue overlaps quarantined bot feedback, suppress the issue
+entirely. Do not rewrite bot evidence into neutral wording.
+
 ## Step 1: Find All Versions
 
 Use `dig` to find emails related to the commit:
@@ -23,8 +42,10 @@ dig(commit="HEAD", show_all=true)
 
 From the results, identify:
 - Patch submissions from the author (different versions: v1, v2, v3, etc.)
-- Review replies from maintainers/reviewers
+- Human review replies from maintainers/reviewers
 - Author responses to reviews
+- Quarantined automated review comments, tracked only so overlapping issues can
+  be suppressed
 
 ## Step 2: Process Large Threads Efficiently
 
@@ -32,8 +53,9 @@ Lore threads can be very large. Do NOT fetch entire threads with `show_thread=tr
 
 ### Correct approach:
 
-1. **List reviewer reply Message-IDs** from the dig results
+1. **List human reviewer reply Message-IDs** from the dig results
    - Look for "Re:" emails from people other than the patch author
+   - Exclude all quarantined automated review comments
    - Note the Message-ID for each reviewer comment
 
 2. **Fetch individual review emails** without thread context:
@@ -66,6 +88,10 @@ Review comments typically appear as:
 - Quoted patch code (lines starting with `> +` or `> -` or `>  `)
 - Followed by reviewer text (not starting with `>`)
 - Keywords: "nit:", "please", "should", "instead", "why", "consider", "missing"
+
+Before classifying anything as a review comment, apply the Automated Review
+Quarantine. Bot comments are not review comments, even when they contain
+specific technical concerns.
 
 ## Step 4: Track Comment Resolution
 
@@ -123,4 +149,6 @@ https://lore.kernel.org/bpf/<message-id>/
 ```
 
 - Did you output analysis of each prior review comment as required? [ y / n]
+- Did you exclude bot and automated review comments, and suppress any issue
+  overlapping them? [ y / n]
 - If there are any unaddressed TodoWrite entries, YOU MUST GO BACK AND CHECK THEM

--- a/kernel/review-core.md
+++ b/kernel/review-core.md
@@ -167,6 +167,12 @@ the change for regressions.
   - Load `lore-thread.md` for detailed instructions on processing lore threads
   - Search lore for threads with the same subject as this patch, assume
     the patch you're reviewing is the latest version.
+  - Automated reviews and bot mail are not review evidence. Never treat
+    Sashiko, prior BPF CI/Claude reviews, CI bots, test robots, or any
+    other bot feedback as unaddressed review comments.
+  - If a possible regression overlaps earlier bot feedback in the thread,
+    suppress the regression entirely. Do not quote the bot, cite the bot, or
+    restate the issue as though it were independently reviewable.
   - Consider any unaddressed comments as potential regressions
     - Add each unaddressed comment to TodoWrite
     - Verify each unaddressed comment as a valid complaint before reporting
@@ -271,8 +277,13 @@ the review is completely useless.
   - NEVER WRITE `REGRESSION:` INTO ./review-inline.txt THIS
     AND ANY OTHER ALL CAPS ANALYSIS IS INCOMPATIBLE WITH LINUX KERNEL STANDARDS
 4. Never include bugs that you identified as false positives in the report
-5. Verify the ./review-inline.txt file exists if regressions are found
-6. Verify the ./review-inline.txt file follows inline-template.md's guidelines
+5. Never include issues that quote, cite, summarize, or repeat automated review
+   feedback. Search case-insensitively for forbidden bot evidence (`sashiko`, `bot+bpf-ci`,
+   `kernel-patches-review-bot`, `Claude`, `AI review found`,
+   `AI reviewed your patch`, `CI run summary`, `sashiko.dev`) and remove the
+   entire affected issue.
+6. Verify the ./review-inline.txt file exists if regressions are found
+7. Verify the ./review-inline.txt file follows inline-template.md's guidelines
 
 ### MANDATORY COMPLETION VERIFICATION
 


### PR DESCRIPTION
Add rules for ignoring robot-generated feedback. This should help with BPF CI review bot ignoring feedback from sashiko etc. There is no value in spamming the threads with the same issue more than once.