### PR TITLE
arm64: make the SCTLR_EL2_RES1 example robust to init drift

### DIFF
--- a/kernel/subsystem/arm64.md
+++ b/kernel/subsystem/arm64.md
@@ -151,10 +151,12 @@ Do not look to the generated mask for feature conditionality — it is not there
 "RES1 only when a feature is absent" (e.g. `SCTLR_ELx.{EIS, EOS}` are RES1 when
 `FEAT_ExS` is unimplemented) lives in KVM's runtime feature map, tagged
 `AS_RES1` ("RES1 when not supported") in `arch/arm64/kvm/config.c`, not in
-`<REG>_RES1`. `INIT_SCTLR_EL2_MMU_ON` above does not set `EIS`/`EOS` at all
-(the EL2 init leaves them `0`); where the kernel does force them to `1` — the
-EL1 inits `INIT_SCTLR_EL1_MMU_ON` / `INIT_SCTLR_EL1_MMU_OFF` — it uses the
-dedicated `SCTLR_EL1_EIS` / `SCTLR_EL1_EOS` field macros, never a `_RES1` mask.
+`<REG>_RES1`. And do not pin the check to an init macro's *current* contents
+either: both the value of a `_RES1` aggregate and the explicit field-macro terms
+an init ORs in (e.g. `SCTLR_ELx_EIS` / `SCTLR_ELx_EOS`) drift between releases.
+`INIT_SCTLR_EL2_MMU_ON` is a live example — it set neither `EIS` nor `EOS` in one
+release and forces both, via the field macros, in a later one. Read the consuming
+init at the revision under review, not from memory.
 
 - **Trigger.** A patch touches a `.sysreg` file so as to allocate bits or
   change a field's RES0 / RES1 classification, regenerating an aggregate


### PR DESCRIPTION
Follow-up to 53a06ba.

The `SCTLR_EL2_RES1` worked example in the "Auto-Generated Definitions and
Semantic Drift" section pinned itself to one revision's `INIT_SCTLR_EL2_MMU_ON`
contents, which then drifted: commit `d7396a72eae7` ("KVM: arm64: Make EL2
exception entry and exit context-synchronization events"), in mainline after
v7.1-rc3, added `SCTLR_ELx_EIS | SCTLR_ELx_EOS` to that init. So the example's
"the EL2 init leaves EIS/EOS at 0" claim went stale — the exact drift this
section is about.

Reword so the example asserts no single revision's init contents. The durable
points are kept:

- feature-conditional RES1 lives in KVM's `config.c` (`AS_RES1`), not in the
  generated `<REG>_RES1` mask;
- both a `_RES1` aggregate's value and an init's explicit field-macro terms
  drift between releases — so read the consuming init at the revision under
  review, not from memory.

`INIT_SCTLR_EL2_MMU_ON`'s own EIS/EOS change is now used as the live illustration.

Verified against `~/local/linux` at current master (`v7.1-rc5-870-g9716c086c8e8`).
