### PR TITLE
review: add AI-slop detection as a subjective review pass

### DIFF
--- a/kernel/agent/report.md
+++ b/kernel/agent/report.md
@@ -131,11 +131,30 @@ Do not count dropped issues in:
 - `review-inline.txt`
 - `review-metadata.json`
 
+### Slop gate (subjective findings)
+
+Some FILE-N issues are subjective "slop" observations (`issue_type: "subjective"`,
+`issue_category: "slop"`) — stylistic opinions from the review agent's subjective pass, never
+bugs. They must not pile onto a patch that has a real problem.
+
+After Automated Review Suppression, if the combined issue set contains ANY confirmed
+correctness regression (`issue_type: "regression"`) or a verified-false syzkaller claim, DROP
+all slop findings before counting or rendering. Slop only surfaces when the patch is otherwise
+clean.
+
+Surviving slop findings render exactly like SR-* subjective reviews per `inline-template.md`:
+"this isn't a bug, but ...", framed as a question about the specific code or prose, naming the
+exact snippet, never an accusation and never implying the code is machine-generated. Use the
+issue's `suggested_question` as the basis for the comment. Slop is always `issue_severity:
+"low"` and never raises the overall severity above `low`.
+
 **Issue types**: Each issue may have an `issue_type` field:
 - `"regression"` (default if field is absent): confirmed bug with proof
 - `"potential-issue"`: guide-directive flagged pattern where the agent is
   uncertain. These have additional `guide_directive` and `agent_analysis` fields
   documenting both perspectives.
+- `"subjective"`: a low-severity style opinion (e.g. `issue_category: "slop"`), gated and
+  rendered as described in the Slop gate above. Never a bug.
 
 Track totals after Automated Review Suppression:
    - Total issues found (regressions + guide-flagged), including lore and syzkaller

--- a/kernel/agent/review.md
+++ b/kernel/agent/review.md
@@ -25,6 +25,7 @@ PHASE-3: Bulk semcode loading
 --- per CHANGE (expand for each FILE-N-CHANGE-M) ---
 FILE-N-CHANGE-M-step-1 through step-8 (including step-6b)
 --- end per CHANGE ---
+PHASE-4.5: Subjective slop pass (high bar)
 PHASE-5: Batch write results
 ```
 
@@ -72,6 +73,7 @@ number, and list of CHANGEs from index.json. Process ALL CHANGEs sequentially.
 - `<prompt_dir>/technical-patterns.md`
 - `<prompt_dir>/callstack.md`
 - `<prompt_dir>/subsystem/subsystem.md`
+- `<prompt_dir>/slop-indicators.md` (subjective slop indicators; the concrete arm of subjective-review.md, used in PHASE 4.5)
 - All `./review-context/FILE-N-CHANGE-M.json` files for this FILE-N
 
 **IMPORTANT**: Change files always use the `.json` extension. The orchestrator
@@ -303,6 +305,38 @@ After Steps 1-8, output:
 
 ---
 
+## PHASE 4.5: Subjective slop pass (high bar)
+
+After the regression analysis, do one light subjective pass over this FILE-N for "slop" —
+stylistic tells like restating/verbose comments, repeated deep-deref chains, copy-paste,
+churn, dead additions, or weak naming. This is the concrete arm of subjective review; findings
+are opinions, never bugs, and report.md drops them if the patch has a real regression.
+
+Skip this pass if the prompt asked to skip slop or subjective review.
+
+Apply `slop-indicators.md` (loaded in PHASE 1) with the discipline in
+`false-positive-guide.md` section 11.1:
+- **Defer to correctness.** Do not raise slop on any code you flagged as a regression above.
+  Slop is style only.
+- **High bar / cluster.** Keep only concrete, located findings with corroboration. Compare to
+  the surrounding code (use the semcode/grep tools already loaded in PHASE 1/3 — do not guess at
+  the neighbours); if there is a plausible reason for the pattern, stay silent.
+- **Never imply authorship.** Do not say or hint the code is AI/tool/machine generated, and do
+  not mention the author. Talk only about the code.
+- **Cap at 3** slop findings for this FILE-N; prefer the most objective (copy-paste, dead code,
+  weak changelog) over the softer ones (verbose, naming, churn, comments).
+- If this is FILE-1, also assess the commit message for SLOP-MSG (what-not-why, verbose padding,
+  non-kernel changelog format). Other FILE-N agents do not touch the commit message.
+
+Collect each kept finding as an issue for PHASE 5 with: `issue_type: "subjective"`,
+`issue_category: "slop"`, `slop_indicator: "<SLOP-...>"`, `issue_severity: "low"`, the verbatim
+snippet in `issue_context`, a neutral `issue_description` about the code only, and a gentle
+`suggested_question`. Commit-message findings use `"file_name": "COMMIT_MESSAGE"`.
+
+Output: `SLOP PASS: <count> kept | none`
+
+---
+
 ## PHASE 5: Batch Write Results
 
 After ALL CHANGEs are processed, write `./review-context/FILE-N-review-result.json`
@@ -343,3 +377,5 @@ Output file: FILE-N-review-result.json
 3. ALWAYS create `FILE-N-review-result.json` — the orchestrator requires it
 4. Use exact code from files for issue_context
 5. You only process ONE FILE-N per invocation
+6. Any PHASE 4.5 slop findings go in the same `regressions` array with
+   `issue_type: "subjective"`, `issue_category: "slop"`; report.md gates and renders them.

--- a/kernel/false-positive-guide.md
+++ b/kernel/false-positive-guide.md
@@ -189,6 +189,30 @@ the dismissal is invalid. Report the race.
 nearby code, nearby comments, and the "debate yourself" section of the
 verification checklist.
 
+### 11.1 Slop observations (SLOP-* / issue_category "slop")
+
+Slop findings are the most subjective of all and carry the highest false-positive risk.
+The verification bar is correspondingly the highest. These checks apply only to slop findings
+(from `agent/review.md`'s PHASE 4.5 subjective slop pass), in addition to section 11.
+
+- **Never infer authorship.** Presence of a stylistic tell is not proof a tool wrote the code,
+  and absence is not proof a human did. Never report "this looks AI-generated", never name a
+  tool, never mention the author. A finding that depends on an authorship claim is invalid;
+  drop it.
+- **Cluster requirement.** Keep a slop finding only if it is concrete, precisely located, and
+  corroborated (the same tell repeated, or a second tell in the same change). A single weak or
+  isolated signal is a false positive; drop it.
+- **Compare to the neighbours.** The kernel is full of long, dense, complex code. If the
+  surrounding code in the same file/subsystem does the same thing, or there is a plausible
+  engineering reason for the pattern, drop the finding.
+- **Defer correctness.** If the concern is really about whether the code is correct, it is not a
+  slop finding — drop it here and let the regression pass own it. Slop is style/clarity only.
+- **Debate yourself (section 10) as the author.** Argue why the code is reasonable as written.
+  If you cannot refute that argument with a concrete readability or idiom point, drop it.
+- **Cap and bias to silence.** At most 3 slop findings per patch; keep the most concrete and
+  least arguable. A missed slop nit costs nothing; a wrong or noisy one costs reviewer trust.
+  When in doubt, stay silent.
+
 ### 12. Uninitialized variables
 - assigning to a variable is the same as initializing it.
 - passing uninitialized variables to a function is fine if that function writes

--- a/kernel/inline-template.md
+++ b/kernel/inline-template.md
@@ -38,6 +38,14 @@ the author.
 - If the bug came from SR-* patterns, it is a subjective review.  Don't put a big
   SUBJECTIVE header on it, simply say something similar to: "this isn't a bug, but ..."
 
+- Slop observations (issue_category "slop", SLOP-* indicators) are subjective reviews too.
+  Render them the same gentle way: "this isn't a bug, but ...", framed as a question about the
+  specific code or prose, naming the exact snippet.  Never say or imply the code is
+  AI/tool/machine generated, and never mention the author.  Talk only about the code.
+  - example: "this isn't a bug, but could foo->bar->baz be hoisted into a local here?  it
+    is repeated a few times below."
+  - example: "this isn't a bug, but does the comment add anything over the line below it?"
+
 - Ask your question specifically about the sources you're referencing:
   - If the regression is a leak, don't call it a 'resource leak', ask
     specifically about the resource you seek leaking.  'Does this code leak the

--- a/kernel/slash-commands/kslop.md
+++ b/kernel/slash-commands/kslop.md
@@ -1,0 +1,13 @@
+Read the prompts {{REVIEW_DIR}}/slop-indicators.md and {{REVIEW_DIR}}/subsystem/subjective-review.md
+
+This is a standalone run of the subjective slop pass (normally part of agent/review.md's
+PHASE 4.5, gated by agent/report.md), for testing and calibration.
+
+Assess the top commit, or the provided patch/commit, for the SLOP-* stylistic tells. Apply the
+confidence discipline in {{REVIEW_DIR}}/false-positive-guide.md section 11.1: high bar, cluster
+requirement, compare to neighbouring code, defer correctness to a real review, debate yourself,
+and a hard cap of 3 observations.
+
+Output findings as gentle, question-posed comments per {{REVIEW_DIR}}/inline-template.md
+("this isn't a bug, but ..."), naming the specific code or prose. Never mention the author and
+never imply the code was machine-generated. If nothing clears the bar, say so and emit nothing.

--- a/kernel/slop-indicators.md
+++ b/kernel/slop-indicators.md
@@ -1,0 +1,145 @@
+# AI "slop" indicators
+
+**Risk**: None. Subjective code/prose quality. Slop findings are opinions, never bugs.
+
+**When to check**: this is the concrete arm of subjective review (`subsystem/subjective-review.md`).
+It runs from `agent/review.md`'s subjective slop pass (PHASE 4.5). `agent/report.md` drops any
+slop finding if the patch has a confirmed correctness regression, so slop only reaches the list
+when the patch is otherwise clean. Never raise slop as part of the regression analysis itself.
+
+This guide lists the stylistic tells that frequently appear in machine-generated or
+lightly-reviewed kernel patches. The goal is NOT to label a patch as AI-written. The goal
+is to spot specific, concrete spots where the code or changelog reads as unidiomatic,
+verbose, or careless, and to ask the author a polite question so they can tidy it up before
+human reviewers do.
+
+## What this is NOT
+
+- Not a bug hunt. If a finding is about correctness, it belongs in the regression pass, not
+  here. Defer all correctness questions to the regression analysis. If you catch yourself
+  reasoning about whether the code is correct — a race, lock ordering, a missing balance, an
+  overflow — stop: that is the regression pass's job, not slop.
+- Not an authorship verdict. Presence of a tell is not proof a tool wrote the code, and
+  absence is not proof a human did. Never write "this looks AI-generated", never mention the
+  author, never mention any tool. Talk only about the specific code or prose.
+- Not an attribution check. Disclosure trailers (`Assisted-by:`, `Co-developed-by:`) are
+  normalized provenance metadata, not slop — never comment on them.
+- Not a style-guide sweep. checkpatch already covers mechanical formatting. Only raise things
+  a checkpatch run would miss and a careful human reviewer would actually comment on.
+
+## Confidence model (high bar)
+
+Slop is hard to detect and easy to get wrong, and the mailing list reacts badly to low-signal
+automated nitpicking. Bias heavily toward staying silent.
+
+- **Cluster requirement.** A single weak signal is never enough. Only raise a finding when you
+  have a clearly-located, concrete instance, ideally with corroboration (the same tell
+  repeated, or two different tells in the same change). One redundant comment, one slightly
+  long name, one extra blank line: stay silent.
+- **Compare to the neighbours, not to an ideal.** The kernel is full of long, dense, and
+  complex code. Judge a change against the surrounding code in the same file/subsystem. If the
+  pattern matches what is already there, or there is a plausible reason for it, suppress. Pull
+  the surrounding code with the code-navigation tools the review already has (semcode
+  `find_function` / `grep_functions`, else grep/read on the tree) — do not guess at the
+  neighbours.
+- **Plausible-reason test.** Before raising anything, ask: is there a sane engineering reason a
+  competent kernel developer would have written it this way? If yes, suppress.
+- **Hard cap.** At most 3 slop questions for a patch. Pick the most concrete and least
+  arguable. Volume is itself the problem we are trying to avoid.
+
+## Indicators
+
+For each indicator: the signal, how to confirm it against nearby code, the kernel norm behind
+it, and an example of the kind of question to pose. Phrase every finding as a question about
+the specific code, varying the wording (see `inline-template.md`).
+
+### SLOP-COMMENT: comments that restate the code
+- Signal: a comment that paraphrases the very next line, narrates unrelated subsystem internals
+  (e.g. justifying a libbpf change by citing `seq_file`/`seq_path` buffer behaviour the reader
+  does not need), or explains the obvious. Block comments not matching the surrounding style.
+- Confirm: read the comment and the code it sits above. If removing the comment loses no
+  information a kernel developer wouldn't already have, it is a candidate. Compare comment
+  density to the rest of the function/file.
+- Norm: coding-style — comments explain WHY, not WHAT; avoid over-commenting.
+- Question: "Does this comment add anything over the code below it, or could it be dropped?"
+
+### SLOP-VERBOSE: verbose / deeply-nested code that reads as machine-written
+- Signal: the same long dereference chain (`a->b->c->d`) repeated several times instead of a
+  local; indentation deeper than the surrounding code without need; gratuitous wrapper/alias
+  layers.
+- Confirm: count the repeats; check whether a local variable or early `return`/`goto` would
+  flatten it, and whether nearby code already does so.
+- Norm: coding-style — shallow indentation, readable locals over repeated derefs.
+- Question: "Could `x->y->z->w` be hoisted into a local here to make this easier to read?"
+
+### SLOP-COPYPASTE: duplicated logic instead of factoring
+- Signal: a block that is a near-verbatim copy of an existing function/block; a "no functional
+  change" refactor that copy-pastes a chunk under a new label instead of sharing it.
+- Confirm: locate the original via grep/semcode and diff the two by eye. Confirm they are
+  substantially the same logic, not coincidentally similar.
+- Norm: submitting-patches — avoid gratuitous duplication; factor shared logic.
+- Question: "This looks close to <existing>() — could the two share a helper?"
+
+### SLOP-DEFENSIVE: redundant guards (style angle only)
+- Signal: a NULL/bounds/overflow check added where the surrounding contract already guarantees
+  the condition cannot occur, read purely as clutter.
+- Confirm: only raise as slop if the redundancy is obvious from local context. If reachability
+  is genuinely in question, that is a correctness matter — leave it to the regression pass and
+  do not raise it here.
+- Norm: coding-style — do not add unreachable/defensive checks without a real trigger.
+- Question: "Is this check reachable, or is the value already constrained by the caller?"
+
+### SLOP-DEADCODE: additions with no consumer
+- Signal: a new enum value, BTF id, label, local, or helper that nothing references; a guard
+  that is always false.
+- Confirm: grep for the new symbol; if it has no user in the series, it is a candidate.
+- Norm: coding-style — no dead code or unused symbols; build clean.
+- Question: "Is `<symbol>` used anywhere in the series, or is it left over?"
+
+### SLOP-CHURN: cosmetic edits with no behavioural reason
+- Signal: reformatting, renaming, or moving code with no functional justification, especially
+  folded into an otherwise focused change.
+- Confirm: check the commit message for a stated reason; if the motion is unexplained and
+  unrelated to the patch's purpose, it is a candidate.
+- Norm: submitting-patches — separate logical changes; no churn-only edits in a feature patch.
+- Question: "Is this rename/move needed for the change, or could it be split out?"
+
+### SLOP-OVERENG: heavy machinery for a small problem
+- Signal: a large new mechanism, abstraction, or reinvented standard helper (open-coding what
+  a builtin or existing kernel facility already provides) for a narrow use case.
+- Confirm: identify the existing facility it duplicates; weigh the added lines against the
+  problem size.
+- Norm: submitting-patches — smallest change that solves the problem; reuse existing infra.
+- Question: "Is the existing <facility> usable here instead of this new mechanism?"
+
+### SLOP-NAMING: identifiers that fight kernel convention
+- Signal: overlong descriptive identifiers where a terse local is the norm; opaque numeric or
+  encoded test names; vendor/marketing names instead of accurate kernel terms.
+- Confirm: compare against naming of nearby identifiers of the same kind.
+- Not slop: width/size literals the language forces (e.g. `%15s` / `%4095[^\n]` in scanf/printf
+  format strings, which cannot interpolate a macro), and any literal that already matches the
+  file's dominant idiom. Do not spend effort on these.
+- Norm: coding-style — clear, concise, conventional names; terse locals, descriptive globals.
+- Question: "Would a shorter name like `<suggestion>` read better alongside the nearby code?"
+
+### SLOP-MSG: changelog that explains the what, not the why
+- Signal: a commit message that narrates the diff line-by-line, pads length while omitting the
+  load-bearing rationale, or uses a non-kernel changelog format (e.g. a `Test Plan:` block).
+- Confirm: read the whole message; check whether a reviewer learns *why* the change is needed
+  and how the tricky part works, or only *what* lines changed.
+- Norm: submitting-patches — describe the problem and the why; imperative mood; concise.
+- Question: quote the specific portion and ask, e.g. "Could the changelog say why this is
+  needed rather than restating the diff?" (use `inline-template.md`'s Commit Message Issues
+  format).
+
+## Output marking
+
+Every slop finding is a subjective observation. Emit it with:
+- `issue_category: "slop"`
+- `slop_indicator: "<SLOP-...>"`
+- `issue_severity: "low"`
+- `issue_type: "subjective"`
+
+`report.md` and `inline-template.md` render these like SR-* subjective findings: gentle,
+question-posed, "this isn't a bug, but ...", no author mention, no ALL CAPS, naming the exact
+code or prose.

--- a/kernel/subsystem/subjective-review.md
+++ b/kernel/subsystem/subjective-review.md
@@ -4,6 +4,11 @@
 
 **When to check**: mandatory for all non-trivial commits
 
+**Slop (concrete, always-on arm):** the indicators in `slop-indicators.md` are the concrete,
+high-confidence part of this subjective review. `agent/review.md` runs them on every patch
+(PHASE 4.5) and `agent/report.md` gates them so they only surface when the patch is otherwise
+clean. Apply them with the high bar in `false-positive-guide.md` section 11.1.
+
 IMPORTANT: never flag single dumb grammar changes: ex its vs it's, unless you
 have a collection of them that make the commit message/comment hard to understand
 


### PR DESCRIPTION
Flag stylistic tells of machine-generated patches (verbose/restating comments, deep dereference chains, copy-paste, churn, weak naming and changelogs) as polite, question-posed observations.

Reuses the existing subjective-review machinery instead of a new phase: runs in review.md (PHASE 4.5), gated and gently rendered by report.md (dropped when the patch has a real regression), at the high bar in false-positive-guide.md section 11.1.

The slop-indicators.md catalog is derived from a three-month analysis of bpf-list reactions to AI patches, and was calibrated against real patches humans had flagged as slop: neighbour comparison uses the review's semcode/grep tools, disclosure trailers and language-forced literals are excluded, and all correctness is deferred to the regression pass.