### PR TITLE
arm64: ground the reviewer against ARM ARM confabulation

### DIFF
--- a/kernel/subsystem/arm64.md
+++ b/kernel/subsystem/arm64.md
@@ -17,6 +17,108 @@ different mode or hardware version onto this code. A genuinely suspect patch has
 a reason you can quote from a loaded guide or the code: report that, never the
 unverified recall.
 
+## ESR_ELx syndrome: exception class, the IL bit, and ISS sub-fields
+
+`ESR_ELx` holds the syndrome of a synchronous exception or an SError, including one that
+software synthesizes to inject: the Exception Class `EC` in bits[31:26], the
+Instruction Length `IL` in bit[25], and the Instruction Specific Syndrome `ISS`
+in bits[24:0] (`ESR_ELx_EC_SHIFT`, `ESR_ELx_IL`, `ESR_ELx_ISS_MASK` in
+`arch/arm64/include/asm/esr.h`). The ISS layout is per-EC: the same ISS bit
+means different things under different exception classes, so an ISS sub-field
+is defined only relative to a stated `EC`. These encodings are the ones the
+grounding note warns about, easy to misremember and reliably wrong from recall.
+The ones the in-tree code relies on are pre-verified and stated here, so a
+finding about them is grounded by quoting this section or the code. A finding
+that asserts a different layout from memory is the confabulation to discard.
+
+### The IL bit (bit[25])
+
+`IL` is the instruction-length field. For a trap on a single instruction it is
+0 for a 16-bit instruction and 1 for a 32-bit one. The architecture instead
+sets `IL` to 1 regardless of the trapping instruction's length for a fixed set
+of exceptions: an SError, an Instruction Abort, a PC alignment fault, an SP
+alignment fault, a Data Abort with `ISV == 0`, an Illegal Execution State
+exception, any debug exception other than a Breakpoint instruction (`BRK` /
+`BKPT`) exception, and any exception reported with `EC == 0b000000` (Unknown).
+A correct syndrome for any of these has `IL == 1`.
+
+KVM constructs `ESR_ELx` when it injects an exception into a guest or a nested
+guest, and the constructed value must carry the architecturally required `IL`.
+When the injected exception is one of the kinds above (an injected abort, an
+injected undefined or Unknown exception, an injected SError), the syndrome must
+set `ESR_ELx_IL`. Omitting it yields a syndrome that does not match what
+hardware would have written. This is an architectural requirement, not a
+property of any one change, so check the injection paths in the tree under
+review and confirm each sets `IL` for the exception kind it raises.
+
+### ISS sub-fields are per-EC
+
+Two exception classes whose ISS the in-tree exception-injection code uses:
+
+- **ERET trap, `EC == 0x1A`** (`ESR_ELx_EC_ERET`, EL2 only: an `ERET`,
+  `ERETAA`, or `ERETAB` trapped by `HCR_EL2.NV`):
+    - bit[1] `ESR_ELx_ERET_ISS_ERET` (`0x2`): 0 = plain `ERET`, 1 = an
+      authenticating `ERETAA` / `ERETAB`.
+    - bit[0] `ESR_ELx_ERET_ISS_ERETA` (`0x1`): which key an `ERETAx` used,
+      0 = A key (`ERETAA`), 1 = B key (`ERETAB`). RES0 when bit[1] is 0.
+    - bits[24:2] RES0.
+
+  In-tree, `esr_iss_is_eretax()` tests bit[1] and `esr_iss_is_eretab()` tests
+  bit[0].
+- **PAC Fail (FPAC), `EC == 0x1C`** (`ESR_ELx_EC_FPAC`: a pointer-authentication
+  failure, raised when `FEAT_FPAC` is implemented). The ARM ARM names its two
+  ISS bits:
+    - bit[1] `DnI`: which key class failed, 0 = Instruction key, 1 = Data key.
+    - bit[0] `BnA`: which key failed, 0 = A key, 1 = B key.
+    - bits[24:2] RES0.
+
+### Worked example: an FPAC syndrome built from a failed ERETAx (do NOT flag)
+
+When an emulated `ERETAA` / `ERETAB` fails to authenticate and an FPAC exception
+is delivered, KVM (`kvm_emulate_nested_eret()`,
+`arch/arm64/kvm/emulate-nested.c`) reuses the ERET-trap syndrome it already
+holds, masking the ISS down to the bits that carry over and re-stamping the
+`EC`. The correct construction is:
+
+```c
+esr &= (ESR_ELx_ERET_ISS_ERETA | ESR_ELx_IL);
+esr |= FIELD_PREP(ESR_ELx_EC_MASK, ESR_ELx_EC_FPAC);
+```
+
+A finding that this builds the FPAC ISS incorrectly is the confabulation to
+discard. Read it against the two ISS layouts above:
+
+- ISS bit[0] lines up. Under `EC == 0x1A` it is `ERETA` (A vs B key), under
+  `EC == 0x1C` it is `BnA` (A vs B key): same position, same polarity (0 = A,
+  1 = B). Keeping bit[0] carries the failing key's A/B sense into the FPAC
+  syndrome unchanged.
+- ISS bit[1] is cleared, so FPAC `DnI == 0` (Instruction key). That is correct:
+  `ERETAA` / `ERETAB` authenticate the return address with the instruction keys
+  `APIAKey_EL1` / `APIBKey_EL1`, so a PAC Fail from an `ERETAx` is always an
+  instruction-key failure.
+- `IL` is kept. An `ERET` / `ERETAx` is a 32-bit A64 instruction, so its trap
+  syndrome has `IL == 1`, which is also the `IL` the resulting FPAC exception
+  requires.
+
+The general check: when code turns one EC's syndrome into another's by masking
+and re-stamping the `EC`, a carried-over ISS bit is correct exactly when its
+position and polarity match between the two layouts. That is verifiable from
+the encodings, with no recall.
+
+**REPORT as bugs:**
+- A synthesized `ESR_ELx` for an injected exception in the `IL == 1` list above
+  (an abort, an Unknown or undefined exception, an SError) that does not set
+  `ESR_ELx_IL`.
+- An ISS bit carried unchanged across exception classes when, in the destination
+  class, that bit holds a different field, has opposite polarity, or is RES0.
+
+**Do NOT flag:**
+- The FPAC-from-`ERETAx` construction above. Bit[0] (A/B key) and `IL` carry
+  over correctly, and `DnI` is correctly 0.
+- A claim that an ISS sub-field sits at a different bit, or has opposite
+  polarity, than stated here when that claim rests only on recall. That is the
+  unverifiable-spec confabulation the grounding note rules out.
+
 ## Memory Tagging Extension (MTE) and Tagged Addresses
 
 Mishandling MTE tags or tagged addresses causes `KASAN invalid-access` panics,

--- a/kernel/subsystem/arm64.md
+++ b/kernel/subsystem/arm64.md
@@ -4,6 +4,19 @@ This guide covers architectural invariants, memory ordering rules, and common
 bug patterns for the ARM64 (AArch64) architecture, derived from historical
 lore and the ARM Architecture Reference Manual (ARM ARM).
 
+## Grounding: you do not have the ARM ARM
+
+You do not have the ARM ARM. The ARM facts in the loaded arm64/KVM guides are
+pre-verified for you. Any ARM fact you cannot find in a loaded guide or show in
+the code under review (such as an exact bit position, an ESR exception class or ISS
+sub-field, RES0/RES1 polarity, an ordering rule, or what the architecture traps
+or routes where or designates as guest-owned versus host-owned) is unverified
+recall, and you are reliably wrong on exactly these details. Do not assert
+such a detail as fact or build a finding on it, and do not carry a fact from a
+different mode or hardware version onto this code. A genuinely suspect patch has
+a reason you can quote from a loaded guide or the code: report that, never the
+unverified recall.
+
 ## Memory Tagging Extension (MTE) and Tagged Addresses
 
 Mishandling MTE tags or tagged addresses causes `KASAN invalid-access` panics,


### PR DESCRIPTION
## Summary

Two additive commits to `arm64.md` (+115/-0), both aimed at the same failure
mode: an LLM reviewer with no access to the ARM ARM recalls a hardware encoding
it cannot look up, states it as fact, and flags correct code as buggy.

- `arm64: tell the reviewer it does not have the ARM ARM`. A grounding note:
  treat any ARM fact you cannot find in a loaded guide or show in the code under
  review as unverified recall, and do not build a finding on it.
- `arm64: pre-verify the ESR_ELx IL bit and ERET/FPAC ISS encodings`. Supply the
  specific encodings the first commit asks the reviewer to ground, verified
  against the ARM ARM, so a correct finding can still be grounded by quoting the
  guide.

Scope is `arm64.md` only. The complementary general check (a spec-grounding rule
in `false-positive-guide.md`) is intentionally left out of this PR.

## Motivation

On a recent ESR_ELx.IL series [1], Sashiko (an LLM reviewer that runs these
prompts) invented the FPAC exception's ISS field layout and flagged correct
syndrome-construction code as a bug. The encoding was wrong and the finding was
rejected on the list. Asked the same layout cold several times, the model
returned a different confident wrong answer each time. This is recall of a
specification the model cannot see, and it is unreliable on exactly these
details: an exact bit position, an ESR exception class or ISS sub-field,
RES0/RES1 polarity, an ordering rule.

A grounding note on its own would suppress these confabulations, but it would
also leave the reviewer no way to confirm a correct syndrome-construction patch,
whose encodings are exactly the facts it may no longer assert from recall. The
second commit closes that gap: it states those encodings, pre-verified, so
"unverified recall" becomes "stated in a loaded guide."

Both rules are dual-mode: each says what to FLAG and what NOT to flag.

## Why these encodings

The grounding note requires the spec facts a finding rests on to be grounded,
quotable from a loaded guide or the code rather than recalled. Its complement
must therefore supply the few facts the reviewer actually needs, without trying
to transcribe the architecture. To choose them, I surveyed the arm64 and
KVM/arm64 sources and their Fixes-tagged bug history for the spec details review
keeps turning on. The ESR_ELx exception class, ISS sub-fields, and IL bit recur
in both: the code constructs and decodes these syndromes throughout exception
injection and handling, and real fixes have turned on getting them right. They
are also small to state, so adding them does not bloat the guide. Other parts of
the spec did not meet that bar (recurring in the code, recurring in bugs,
compact) and stay under the grounding note's general rule.

## What is in it

*Grounding note.* The ARM facts in the loaded guides are the reviewer's
pre-verified source. Anything else (a bit position, an ISS sub-field, an
ordering rule, what the architecture traps or owns) is unverified recall: do not
assert it or base a finding on it, and do not carry a fact from a different mode
or hardware version onto this code. A suspect patch has a reason that can be
quoted from a guide or the code, and that is what gets reported.

*ESR_ELx encodings.* The EC / IL / ISS field map; the IL=1 rule (IL is set
regardless of instruction length for instruction aborts, ISV==0 data aborts,
SError, alignment and illegal-state faults, most debug exceptions, and EC==0);
and the per-EC ISS layouts for the ERET trap (EC 0x1A) and PAC Fail (EC 0x1C).
Every encoding is verified against the ARM ARM (DDI 0487) and cross-checked
against the in-tree `esr.h` macros.

The FPAC-from-ERETAx construction ships as a do-not-flag worked example, because
it is the exact code that was mis-flagged. Masking the ERET-trap ISS down to
`ERETA | IL` and re-stamping the EC to FPAC is correct: ISS bit[0] is the
A/B-key bit under both exception classes, the cleared bit[1] gives `DnI == 0`
(ERETAx authenticates with the instruction keys), and `IL == 1` is right for a
32-bit ERET. The rule is written tree-independently, so it does not depend on
that series landing.

## Validation

A/B on the grounding note, vanilla prompts vs +note, five runs each of Sashiko
(running these prompts) on Gemini at temperature 1.0. The FPAC ISS confabulation
survived to the final report in 1 of 5 baseline runs and 0 of 5 with the note.
The sample is small and the reviewer is noisy at this temperature, so the number
is directional rather than a measured effect size, but the specific mis-flagging
that prompted the change did not recur under the note.

[1] https://lore.kernel.org/all/20260619070719.812227-1-tabba@google.com/
