### PR TITLE
kernel: subsystem: input: document force-feedback and devm lifetime r…

### DIFF
--- a/kernel/subsystem/input.md
+++ b/kernel/subsystem/input.md
@@ -8,6 +8,18 @@ unbind.
 
 *   **Allocation**: Devices must be allocated using `input_allocate_device()` or
     `devm_input_allocate_device()`.
+*   **Capabilities**: The core automatically adds `EV_SYN`/`SYN_REPORT`
+    capability to all input devices. Manual addition is redundant.
+*   **Pre-registration state**: `input_event()` can be called safely after
+    allocation but before registration. It updates internal state (like
+    `keybit` or the current value of an absolute axis) but will not propagate
+    events to handlers. This allows drivers to request IRQs and handle initial
+    state synchronization before the device is visible to userspace.
+*   **Registration Visibility**: `input_register_device()` is the point where
+    the device becomes visible to userspace. All driver private data and
+    callbacks MUST be fully initialized (including `input_set_drvdata()`) BEFORE
+    calling register. Once registered, callbacks can be invoked immediately by
+    the core or via userspace ioctls.
 *   **Registration Transition**: Once `input_register_device()` succeeds, the
     input core takes over part of the lifecycle management.
     *   **REPORT as bugs**: Any code that calls `input_free_device()` on a pointer
@@ -16,22 +28,27 @@ unbind.
         and then set `dev = NULL` before a shared `input_free_device(dev)`
         call. This "defensive NULL" pattern is safe and should NOT be reported
         as a bug, as `input_free_device(NULL)` is a no-op.
-*   **Pre-registration state**: `input_event()` can be called safely after
-    allocation but before registration. It updates internal state (like
-    `keybit` or the current value of an absolute axis) but will not propagate
-    events to handlers. This allows drivers to request IRQs and handle initial
-    state synchronization before the device is visible to userspace.
-*   **Capabilities**: The core automatically adds `EV_SYN`/`SYN_REPORT`
-    capability to all input devices. Manual addition is redundant.
 *   **Lifetime Guarantee**: The input core uses reference counting to manage the
     `input_dev` object. Even after `input_unregister_device()` is called, the
     memory for the device will remain valid until the last userspace reference
     (e.g., via `evdev`) is released.
-*   **Registration Visibility**: `input_register_device()` is the point where
-    the device becomes visible to userspace. All driver private data and
-    callbacks MUST be fully initialized (including `input_set_drvdata()`) BEFORE
-    calling register. Once registered, callbacks can be invoked immediately by
-    the core or via userspace ioctls.
+*   **Unregistration and Handler Disconnection**: When a device is unregistered
+    (via `input_unregister_device()`), the input core immediately disconnects all
+    handlers (such as `evdev`).
+    *   Handlers are notified that the device is "dead" (e.g., `evdev->exist = false`
+        is set under mutex).
+    *   Once disconnected, no new userspace requests (ioctls, opens, event writes)
+        can reach the driver. Any pending synchronous operations are completed
+        before the disconnect returns.
+    *   Consequently, the lifecycle mismatch (where `input_dev` outlives the
+        driver's private data) is **completely safe for all synchronous paths**.
+        Drivers do not need defensive checks in callbacks like `open` or `close`
+        to guard against unbind.
+    *   **CRITICAL EXCEPTION**: This protection **only** applies to synchronous
+        calls initiated by handlers. Asynchronous background tasks (such as
+        force-feedback timers or driver-local workqueues) are NOT blocked by
+        disconnection and must be explicitly stopped (see **Timer Lifetime**
+        under *Force-Feedback Memory Management*).
 
 See `input_allocate_device()` and `input_register_device()` in
 `drivers/input/input.c`.
@@ -69,6 +86,17 @@ private data that differ from the rest of the input core.
 *   **Allocation Requirement**: Because the input core calls `kfree()` on the
     private data, it MUST be allocated using `kmalloc()` (or similar) and MUST
     NOT be managed by `devm`.
+*   **Timer Lifetime (Force-Feedback)**: Force-feedback devices (especially
+    `ff-memless`) use background timers to schedule haptic effects.
+    *   The input core automatically stops these timers synchronously during
+        `input_unregister_device()` (via the `ff->stop` callback).
+    *   Drivers must still ensure that any local asynchronous work (e.g.,
+        custom workqueues used to defer haptic writes) is explicitly cancelled
+        in their `close()` or `remove()` callbacks to prevent UAF.
+    *   **Context**: While the core guarantees that synchronous handler-initiated
+        callbacks are safe after unregistration (see **Unregistration and
+        Handler Disconnection**), asynchronous background tasks must be manually
+        reclaimed because they are not governed by handler disconnection.
 *   **REPORT as bugs**: Any driver that manually frees the data passed to
     `input_ff_create_memless()` or uses `devm_kzalloc()` for it, as this will
     lead to double-frees or manual-free-of-managed-memory.
@@ -89,9 +117,41 @@ unregistration).
 *   **Redundant Parent**: When using `devm_input_allocate_device(dev)`, the core
     automatically sets `input_dev->dev.parent = dev`. Manually assigning the
     parent is redundant and should be avoided.
-*   **REPORT as bugs**: Explicitly calling `input_unregister_device()` on a
-    device allocated via `devm_input_allocate_device()` is usually redundant
-    and can lead to double-unregistration.
+*   **Manual Cleanup of Managed Devices (Safety & Redundancy)**:
+    *   **Freeing**: It is perfectly fine to call `input_free_device()` on a
+        device allocated via `devm_input_allocate_device()` (e.g., in a failed
+        `probe` path before registration). The input core detects this,
+        automatically removes the devres tracking synchronously, and frees the
+        device, preventing any double-free or leak when the devm cleanup
+        eventually triggers.
+    *   **Unregistering**: Explicitly calling `input_unregister_device()` on a
+        managed device (usually in `remove()`) is usually redundant but is
+        **technically safe** and should NOT be reported as a bug. The input core
+        detects this, automatically removes the devres unregister action
+        synchronously to prevent double-unregistration, and unregisters the
+        device immediately.
+*   **Analysis Protocol: Eliminating Manual Unregistration**:
+    When reviewing a driver that explicitly calls `input_unregister_device()` on a
+    managed device (usually in `remove()`), perform a deep analysis to see if it
+    can be safely eliminated to simplify the code:
+    1.  **Identify Non-Devm Async Resources**: Check if the driver manages any
+        non-devm asynchronous resources (e.g., custom workqueues, timers, or
+        non-devm IRQs) that are destroyed/freed in the `remove()` callback.
+    2.  **Check Dependency**: Determine if these resources can receive new work
+        or events triggered by input device callbacks (like `play_effect` or `open`).
+        *   If yes, the input device **must** be unregistered *before* these
+            resources are destroyed.
+        *   Since the `remove()` callback runs *before* devm auto-unregistration
+            triggers, a manual `input_unregister_device()` is **required** in
+            `remove()` before the resource cleanup. It cannot be eliminated.
+    3.  **Check Devm Ordering**: If all resources are devm-managed, verify if
+        they are allocated/registered in the correct order (LIFO): the input device
+        registration must happen *after* the allocation of any resource it depends
+        on, so that the input device is unregistered *before* those resources
+        are freed.
+    4.  **Recommendation**: If there are no non-devm dependencies and devm ordering
+        is correct, the manual `input_unregister_device()` call is truly redundant
+        and you should recommend its removal.
 *   **Ordering**: Drivers should avoid mixing managed and regular resources. If
     both are used, non-managed resources (like manual IRQ requests) should be
     acquired *after* managed ones and released *manually* before the managed


### PR DESCRIPTION
…ules

- Document that synchronous paths are safe after unregistration due to handler disconnection.
- Document that force-feedback timers are stopped by the core, but drivers must cancel local async work.
- Document safety of manual freeing and unregistration of managed devices.
- Add an analysis protocol to determine if manual unregistration is redundant or required.
- Restructure the Lifecycle section to follow a chronological driver setup, registration, and teardown flow.
- Consolidate devm manual freeing/unregistration rules into a single cohesive "Manual Cleanup" section, removing redundant style notes.
- Add explicit cross-references between handler disconnection (synchronous safety) and timer lifetimes (asynchronous risks) to clarify the architectural rationale.