### PR TITLE
kernel: add a citation drift checker for the subsystem guides, and fix the drift it found

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -1,0 +1,56 @@
+# Citation drift check for the onboarded arm64/KVM subsystem guides.
+#
+# This runs kernel/scripts/check-drift.py against a kernel tree and reports any
+# guide citation that no longer resolves. The same check runs locally, and that
+# is the primary path: against a full working kernel tree it verifies every
+# class of citation (paths, symbols, commits, and the verification footer):
+#
+#   python3 kernel/scripts/check-drift.py --tree /path/to/linux --require-footer \
+#       kernel/subsystem/arm64.md kernel/subsystem/kvm.md \
+#       kernel/subsystem/kvm-arm64.md kernel/subsystem/hyp-arm64.md
+#
+# CI cannot afford a full kernel clone, so it uses a depth-1 clone. That tree
+# has the tip's files but no commit history, so the checker skips the
+# commit-history checks (commit SHAs, commit subjects, and the footer's ancestry
+# check) and verifies paths and symbols, which is where citations rot in
+# practice. See kernel/docs/drift-checker.md for the check model.
+
+name: drift-check
+
+on:
+  pull_request:
+    paths:
+      - 'kernel/subsystem/**'
+      - 'kernel/scripts/check-drift.py'
+      - 'kernel/docs/drift-checker.md'
+      - '.github/workflows/drift-check.yml'
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC, to catch drift as the kernel moves
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out review-prompts
+        uses: actions/checkout@v5
+
+      - name: Self-test the checker
+        run: python3 kernel/scripts/check-drift.py --selftest
+
+      - name: Shallow-clone the kernel
+        run: |
+          git clone --depth 1 \
+            https://github.com/torvalds/linux.git "$RUNNER_TEMP/linux"
+
+      - name: Check the onboarded guides
+        run: |
+          python3 kernel/scripts/check-drift.py \
+            --tree "$RUNNER_TEMP/linux" --require-footer \
+            kernel/subsystem/arm64.md \
+            kernel/subsystem/kvm.md \
+            kernel/subsystem/kvm-arm64.md \
+            kernel/subsystem/hyp-arm64.md

--- a/kernel/docs/drift-checker.md
+++ b/kernel/docs/drift-checker.md
@@ -109,6 +109,8 @@ For a guide that has a footer, the checker validates that `rev` resolves and
 is an ancestor of `--rev`, and warns when `date` is more than 90 days old.
 `--require-footer` turns a missing footer into an error for the guides named
 on the command line; continuous integration uses it on the onboarded guides.
+`--all` checks a guide's citations even without a footer, for the pre-onboarding
+run that decides whether the guide is ready to carry one.
 
 The footer is the only markup the checker adds inside a guide. The guides are
 fed to their readers verbatim, so the footer is an HTML comment: it does not

--- a/kernel/docs/drift-checker.md
+++ b/kernel/docs/drift-checker.md
@@ -30,10 +30,15 @@ citation exits non-zero; an age warning does not.
   nowhere in code. Identifiers inside fenced examples are extracted and
   existence-checked the same way, since even a deliberately-wrong example line
   uses real symbol names.
-- **C3, commit.** A hex string of twelve or more digits is checked to resolve
-  to a commit. When the citation is the adjacent `` `<sha>` ("subject") ``
-  form, the quoted subject is compared; a bare backticked subject with no SHA
-  is resolved by a fixed-string substring match over `git log --grep`.
+- **C3, commit.** A hex string of twelve or more digits must resolve to a
+  commit that is an ancestor of `--rev`. A commit that exists in the repository
+  but not in the revision's history is a finding, so a guide checked against an
+  older release flags SHAs that had not yet merged then. When the citation is
+  the adjacent `` `<sha>` ("subject") `` form, the quoted subject is compared.
+  A bare backticked subject with no SHA is matched against commit subjects: a
+  whole-message `git log --grep` narrows the candidates, then only a commit
+  whose subject contains the string counts, so a subject never validates
+  against an unrelated commit's body.
 - **C4, footer.** See Verification footer.
 
 ## Citation forms

--- a/kernel/docs/drift-checker.md
+++ b/kernel/docs/drift-checker.md
@@ -165,6 +165,27 @@ rules do not catch: author shorthand for a longer symbol (`MIN_PKVM` for
 `__KVM_HOST_SMCCC_FUNC_MIN_PKVM`), metavariables (`VNCR_r`), and identifiers
 that appear only in worked examples (`vcpu_reset_args`, `captured_seq`).
 
+## Running the checker
+
+Locally, point the checker at a full working kernel tree. Every check runs,
+including the commit and footer-ancestry checks:
+
+```
+python3 kernel/scripts/check-drift.py --tree /path/to/linux --require-footer \
+    kernel/subsystem/arm64.md kernel/subsystem/kvm.md \
+    kernel/subsystem/kvm-arm64.md kernel/subsystem/hyp-arm64.md
+```
+
+Continuous integration (`.github/workflows/drift-check.yml`) runs the same
+check on a pull request that touches a guide, and once a week to catch drift as
+the kernel moves. A full kernel clone is too expensive for CI, so it uses a
+depth-1 clone. That tree carries the tip's files but no commit history, so the
+checker detects the shallow clone and skips the checks that need history, the
+commit SHAs and subjects (C3) and the footer's ancestor check (C4), while still
+verifying paths and symbols (C1, C2), which is where citations rot in practice.
+A citation is never reported as broken merely because the tree lacks the history
+to check it.
+
 ## Mechanical checking and drift-robust prose
 
 The two are complementary. A worked example can be written so it does not pin

--- a/kernel/docs/drift-checker.md
+++ b/kernel/docs/drift-checker.md
@@ -83,6 +83,23 @@ Not checked:
   cannot meaningfully fail an existence check and is skipped. Every stale
   citation this checker is built to catch resolves to well under that; the
   checked symbols top out below 100 occurrences.
+- **Fragments and family placeholders.** A token that begins with a single
+  underscore or ends with one (`_scoped`, `QCM_`, `_WRITE`) is a prefix or
+  suffix stub, and one whose only capital is a size or level metavariable
+  (`__raw_readN`, `pXd_mkspecial`) names a family, not a symbol. A token
+  extracted after a digit (`_dwlib` out of `8250_dwlib`) is the tail of a
+  digit-led name. These are skipped only when they would otherwise be flagged;
+  a token that resolves is always a real symbol and is kept.
+- **Metasyntactic example identifiers.** A worked example that uses a
+  conventional stand-in (`my_free`, `foo_pm_ops`, `alloc_thing`,
+  `SOME_SUBSYSTEM`) names nothing in the tree. A 0-hit token with a
+  metasyntactic component (`foo`, `my`, `some`, `thing`, `wrapper`, ...) is
+  taken as illustrative.
+- **Documented removals.** A guide often names an absent symbol precisely to
+  say it is gone (`hrtimer_init() is removed; use hrtimer_setup()`). When the
+  citation's own sentence says the token was removed, renamed, or does not
+  exist, flagging it would report a removal the author documents on purpose,
+  so it is not a finding.
 
 ## Symbol corpus
 
@@ -95,6 +112,23 @@ code. `KVM_GET_SUPPORTED_CPUID2`, for example, survives only in
 When a symbol sits on the same line as, or in a paragraph with exactly one,
 backticked path, the checker names that file in the finding. Otherwise the
 lookup is tree-wide.
+
+## Path references
+
+A path citation is resolved against the tree exact, then as a directory, then
+as a unique filename suffix. Some backticked path-shaped tokens are not source
+citations and are skipped: absolute runtime paths (`/proc/meminfo`, `/sys/...`,
+`/dev/zero`), glob, enumeration and metavariable patterns
+(`include/linux/bpf*.h`, `vmg->start/end`, `*_util.h`,
+`tools/testing/selftests/<subsys>/`), and an extensionless slashed token whose
+first component is not a kernel top-level directory. A wildcard or a `<...>`
+metavariable makes a path a pattern wherever it sits, with or without a
+directory component. A bare filename that matches several real files
+(`namei.c`) still exists, so it is not reported as drift.
+
+References into the review-prompts repo itself (a sibling guide such as
+`btf.md`, an agent prompt such as `../agent/review.md`) are verified against
+that repo, not the kernel tree; a missing one is still reported.
 
 ## Verification footer
 

--- a/kernel/docs/drift-checker.md
+++ b/kernel/docs/drift-checker.md
@@ -1,0 +1,133 @@
+# Citation drift checker
+
+The arm64 and KVM subsystem guides under `kernel/subsystem/` cite kernel
+paths, symbols, and commits. The kernel moves, so a citation that was
+accurate when written rots: a function is renamed, a file moves, a symbol is
+removed. `kernel/scripts/check-drift.py` verifies the mechanically checkable
+citations in a guide against a local kernel tree and reports each stale one,
+so the guides can be kept current without a maintainer re-reading every
+reference by hand.
+
+The checker is stdlib-only Python 3 and reaches the kernel tree through git
+plumbing (`git cat-file`, `git grep`, `git log`) only, so it runs wherever
+git and Python are available and never modifies the tree. Every query takes a
+revision (`--rev`, default the tree's `HEAD`), so a guide can be checked
+against any release, and `--stats` prints the per-class checked, skipped, and
+ignored counts.
+
+Diagnostics are one line each, `<guide>:<line>: <check>: <message>`. A broken
+citation exits non-zero; an age warning does not.
+
+## Checks
+
+- **C1, path.** A backticked path is resolved in order: exact path, then
+  directory (trailing slash), then unique suffix match for a bare filename or
+  a trailing fragment such as `nvhe/memory.h`. Zero matches, or a fragment
+  that matches more than one file, is a finding. A guide-internal reference
+  (`see kvm-arm64.md`) is resolved against this repository, not the kernel.
+- **C2, symbol.** A backticked identifier is looked up in the kernel source
+  with `Documentation/` excluded (see Symbol corpus). Reported when it exists
+  nowhere in code. Identifiers inside fenced examples are extracted and
+  existence-checked the same way, since even a deliberately-wrong example line
+  uses real symbol names.
+- **C3, commit.** A hex string of twelve or more digits is checked to resolve
+  to a commit. When the citation is the adjacent `` `<sha>` ("subject") ``
+  form, the quoted subject is compared; a bare backticked subject with no SHA
+  is resolved by a fixed-string substring match over `git log --grep`.
+- **C4, footer.** See Verification footer.
+
+## Citation forms
+
+Occurrence counts across the four guides:
+
+| Form | Occurrences | Checked |
+|------|-------------|---------|
+| File paths (C1) | 41 | 34 |
+| Symbols, prose and fenced code (C2) | 1018 | 291 |
+| Commit SHAs (C3) | 5 | 5 |
+| Commit-subject citations (C3b) | 4 | 4 |
+| Spec references (C5) | 13 | 0 |
+| Illustrative (placeholders, literals, example locals) | 45 | 0 |
+| Other | 4 | 0 |
+
+334 of 1130 citations (30%) are mechanically checked, the count `--stats`
+prints. The remainder are architectural facts, illustrative pseudo-code, and
+tokens too generic to verify.
+
+## What is checked, and what is not
+
+The bar for a check is near-zero false positives and real power. A check that
+cannot fail, because its token occurs throughout the tree, adds nothing even
+though it never misfires. So the checker verifies specific, kernel-namespaced
+citations (functions, kernel macros and config options, types, file paths,
+commit SHAs and subjects) and leaves architectural facts to prose review.
+
+Not checked:
+
+- **Register, field, encoding, and instruction names** (`SCTLR_EL2`,
+  `HCR_EL2.RW`, `CBNZ`, `S12E1R`). These are stated from the Arm Architecture
+  Reference Manual, not from the kernel tree, so a tree lookup cannot confirm
+  them. A token is treated as a kernel symbol only if it is kernel-namespaced:
+  it carries an underscore, or is a lowercase identifier of four or more
+  characters. All-caps or mixed-case names with no underscore are taken as
+  architectural or prose.
+- **Placeholders and wildcards** (`<REG>_RES1`, `ICC_IAR{0,1}_EL1`,
+  `fpsimd_lazy_switch_to_*`). A backticked span containing a wildcard, brace,
+  or angle bracket is a pattern, not a citation.
+- **Generic tokens.** A token that occurs more than 100 times in the corpus
+  cannot meaningfully fail an existence check and is skipped. Every stale
+  citation this checker is built to catch resolves to well under that; the
+  checked symbols top out below 100 occurrences.
+
+## Symbol corpus
+
+Symbols are matched against the kernel source with `Documentation/` excluded.
+A documentation mention must not vouch for a symbol that no longer exists in
+code. `KVM_GET_SUPPORTED_CPUID2`, for example, survives only in
+`Documentation/virt/kvm/review-checklist.rst`, while the code interface is
+`KVM_GET_SUPPORTED_CPUID`; a whole-tree grep would wrongly report it as live.
+
+When a symbol sits on the same line as, or in a paragraph with exactly one,
+backticked path, the checker names that file in the finding. Otherwise the
+lookup is tree-wide.
+
+## Verification footer
+
+A guide opts in to checking by carrying a footer as its last line:
+
+```
+<!-- drift-checked: rev=<commit> date=<YYYY-MM-DD> -->
+```
+
+`rev` is the kernel commit whose tree the guide's citations were last verified
+against (twelve or more hex digits); `date` is when. A guide with no footer is
+skipped with an informational line, so a default run over
+`kernel/subsystem/*.md` stays quiet for guides that have not been onboarded,
+and adoption is per guide.
+
+For a guide that has a footer, the checker validates that `rev` resolves and
+is an ancestor of `--rev`, and warns when `date` is more than 90 days old.
+`--require-footer` turns a missing footer into an error for the guides named
+on the command line; continuous integration uses it on the onboarded guides.
+
+The footer is the only markup the checker adds inside a guide. The guides are
+fed to their readers verbatim, so the footer is an HTML comment: it does not
+render, and does not read as a review instruction.
+
+## Suppressing false positives
+
+Suppression lives in the checker, never as in-guide markup, because a guide is
+delivered verbatim to its readers and an inline ignore comment would travel
+with it. Most non-citations are filtered by the shape and frequency rules
+above. A short explicit skip list in the script covers the residue those
+rules do not catch: author shorthand for a longer symbol (`MIN_PKVM` for
+`__KVM_HOST_SMCCC_FUNC_MIN_PKVM`), metavariables (`VNCR_r`), and identifiers
+that appear only in worked examples (`vcpu_reset_args`, `captured_seq`).
+
+## Mechanical checking and drift-robust prose
+
+The two are complementary. A worked example can be written so it does not pin
+to one release's contents: commit `87f4136` rewrote the `SCTLR_EL2_RES1`
+example to assert no single revision's init-macro contents, which removes that
+citation from the checkable surface entirely. Robust prose reduces how many
+citations there are; the checker verifies the ones that remain.

--- a/kernel/scripts/check-drift.py
+++ b/kernel/scripts/check-drift.py
@@ -1,0 +1,868 @@
+#!/usr/bin/env python3
+"""check-drift.py - report stale citations in the subsystem guides.
+
+The guides under kernel/subsystem/ cite kernel paths, symbols, and commits.
+The kernel moves, so a citation rots: a function is renamed, a file moves, a
+symbol is removed. This checks the mechanically checkable citations in a guide
+against a local kernel tree and prints each stale one, so the guides can be
+kept current without a maintainer re-reading every reference by hand.
+
+The kernel tree is reached through git plumbing (git cat-file, git grep,
+git log) only, so the tree is never modified and any revision can be checked
+(--rev, default the tree's HEAD). Diagnostics are one line each,
+<guide>:<line>: <check>: <message>; a broken citation exits non-zero, an age
+warning does not. See kernel/docs/drift-checker.md for the citation model and
+the check/skip decisions.
+
+Usage:
+    check-drift.py --tree <linux> [--rev REV] [--all] [--require-footer]
+                   [--stats] [--spec-index FILE] guide.md [guide.md ...]
+    check-drift.py --selftest
+"""
+
+import argparse
+import concurrent.futures as cf
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import Counter, defaultdict, namedtuple
+from datetime import date
+
+# --------------------------------------------------------------------------
+# Extraction: parse a guide into candidate citations.
+#
+# A citation is a backticked token in prose, a C identifier inside a fenced
+# example, a >=12-hex commit SHA, or a backticked commit subject. Each is
+# tagged with a class (C1 path, C2 symbol, C3 SHA, C3b subject, C5 spec ref)
+# and a subclass; illustrative tokens (placeholders, literals, example locals)
+# and non-citation prose are tagged so they can be counted but not checked.
+# --------------------------------------------------------------------------
+
+C_KEYWORDS = set("""auto break case char const continue default do double else enum extern
+float for goto if inline int long register return short signed sizeof static struct switch
+typedef union unsigned void volatile while bool true false NULL sizeof""".split())
+
+# Identifiers that appear only as locals in the guides' worked examples.
+SNIPPET_LOCALS = set("""val idx slots hva gfn err out cond flags local_args local_vcpu
+host_args do_sve addr order size handle_hcall update_hyp_state""".split())
+
+COMMIT_VERBS = ("Fix", "Add", "Only", "Make", "Correct", "Initialize",
+                "Remove", "Introduce")
+
+SRC_EXT = re.compile(r"\.(c|h|rst|awk|S|rs|py|txt|sh|sysreg)$")
+SHA_RE = re.compile(r"^[0-9a-f]{12,40}$")
+IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+FENCE_RE = re.compile(r"^\s*```")
+SPAN_RE = re.compile(r"`([^`]+?)`", re.DOTALL)
+NUM_RE = re.compile(r"0[xXbB][0-9A-Fa-f]+")
+SPEC_SECTION = re.compile(r"\b[A-Z][0-9]+(?:\.[0-9]+)+\b")
+ARM_CTX = re.compile(r"Arm ARM|ARM ARM|DDI\s*0487")
+SPEC_ANCHOR = re.compile(r"DDI\s*0487|\bR_[A-Z]{5}\b")
+SHA_IN_TEXT = re.compile(r"\b[0-9a-f]{12,40}\b")
+META = re.compile(r"<[A-Za-z0-9_|,.]+>")             # <REG>, <cc>, <n>, <0|1>
+BRACE_EXPANSION = re.compile(r"\{[^}]*[,|][^}]*\}")   # {0,1}, {I,F}
+MD_REF = re.compile(r"^[A-Za-z0-9._-]+\.md$")         # guide-internal reference
+
+Cite = namedtuple("Cite", "guide line cls sub token raw in_fence")
+
+
+def is_commit_subject(c):
+    s = c.strip()
+    if re.match(r"^(KVM|arm64|kvm-arm64|hyp-arm64)\b.*:\s", s):
+        return True
+    w = s.split()
+    if (len(w) >= 4 and s[0].isupper() and w[0] in COMMIT_VERBS
+            and not re.search(r"[;{}=]|&&|\|\||->|==", s)):
+        return True
+    return False
+
+
+def is_path(c):
+    s = c.strip()
+    if s.startswith("<") or " " in s or s.startswith("http"):
+        return False
+    if s.endswith("/"):
+        return "/" in s.rstrip("/") + "/"
+    if SRC_EXT.search(s):
+        return True
+    if "/" in s and re.search(r"/[a-z][a-z0-9_.-]*$", s):
+        return True
+    return False
+
+
+def looks_placeholder(c):
+    return ("<" in c and ">" in c) or "..." in c or "…" in c
+
+
+def register_field_shape(t):
+    return bool(re.search(r"_EL[012x]\b", t) or re.match(r"^[A-Z][A-Z0-9]*_EL[012x]", t))
+
+
+def macro_shape(t):
+    return bool(re.match(r"^[A-Z_][A-Z0-9_]{2,}$", t))
+
+
+def code_snippet(c):
+    return bool(re.search(r"[;{}]|==|&&|\|\||\breturn\b|\bgoto\b|\bif\b\s*\(", c))
+
+
+def pattern_token(s, start, end):
+    """True when the token at [start:end] in s is a wildcard/metavariable pattern
+    rather than a citation, decided by ADJACENCY only: an immediately-following
+    glob '*' or brace-expansion, or enclosure in a <...> metavariable group. A
+    leading pointer '*', a block brace elsewhere on the line, or a comparison
+    operator does NOT make the token a pattern."""
+    after = s[end:end + 1]
+    before = s[start - 1:start]
+    if after == "*":                                      # ID_AA64*, fpsimd_..._*
+        return True
+    if after == "<" and META.match(s[end:]):              # CB<cc>, GICD_ICENABLER<n>
+        return True
+    if after == "{" and BRACE_EXPANSION.match(s[end:]):   # ICC_IAR{0,1}
+        return True
+    if before == "}":                                     # copy_{from,to}_user
+        return True
+    for mm in META.finditer(s):                           # token inside <...>
+        if mm.start() <= start and end <= mm.end():
+            return True
+    return False
+
+
+class Extractor:
+    """Collects the citations of one guide into self.rows."""
+
+    def __init__(self, guide):
+        self.guide = guide
+        self.rows = []
+
+    def add(self, ln, cls, sub, tok, raw, fence):
+        self.rows.append(Cite(self.guide, ln, cls, sub, tok, raw, fence))
+
+    def classify_ident(self, lineno, t, c, m, snip):
+        if pattern_token(c, m.start(), m.end()):
+            self.add(lineno, "illustrative", "placeholder", t, c, False)
+            return
+        if t.startswith("CONFIG_"):
+            self.add(lineno, "C2", "config", t, c, False)
+        elif t.startswith("FEAT_"):
+            self.add(lineno, "C5", "spec-feature", t, c, False)
+        elif register_field_shape(t):
+            self.add(lineno, "C2", "register-or-field", t, c, False)
+        elif macro_shape(t):
+            self.add(lineno, "C2", "macro", t, c, False)
+        elif snip and t in SNIPPET_LOCALS:
+            self.add(lineno, "illustrative", "snippet-local", t, c, False)
+        elif (t + "()") in c.replace(" ", ""):
+            self.add(lineno, "C2", "function", t, c, False)
+        elif t[0].islower():
+            self.add(lineno, "C2", "function-or-type", t, c, False)
+        else:
+            self.add(lineno, "C2", "type-or-const", t, c, False)
+
+    def process_span(self, lineno, c):
+        if is_commit_subject(c):
+            self.add(lineno, "C3b", "commit-subject", c.strip(), c, False)
+            return
+        if MD_REF.match(c.strip()):
+            self.add(lineno, "C1", "repo-internal", c.strip(), c, False)
+            return
+        if is_path(c):
+            s = c.strip()
+            if s.endswith("/"):
+                sub = "dir"
+            elif "/" in s:
+                sub = "exact" if s.startswith(("arch/", "Documentation/", "include/",
+                      "kernel/", "drivers/", "mm/", "fs/", "tools/", "virt/")) else "fragment"
+            else:
+                sub = "basename"
+            self.add(lineno, "C1", sub, s, c, False)
+            return
+        if SHA_RE.match(c.strip()):
+            self.add(lineno, "C3", "sha", c.strip(), c, False)
+            return
+        if looks_placeholder(c):
+            self.add(lineno, "illustrative", "placeholder", c.strip(), c, False)
+            return
+        snip = code_snippet(c)
+        num_spans = [(m.start(), m.end()) for m in NUM_RE.finditer(c)]
+        for a, b in num_spans:
+            self.add(lineno, "illustrative", "numeric-literal", c[a:b], c, False)
+        idents = [m for m in IDENT_RE.finditer(c)
+                  if m.group(0) not in C_KEYWORDS
+                  and not any(a <= m.start() < b for a, b in num_spans)]
+        if not idents:
+            if not num_spans:
+                self.add(lineno, "other", "no-ident", c.strip(), c, False)
+            return
+        for m in idents:
+            self.classify_ident(lineno, m.group(0), c, m, snip)
+
+
+def extract_citations(text_lines, guide):
+    """Return the citations of one guide (already split into lines)."""
+    ex = Extractor(guide)
+
+    # Prose backtick spans: mask fenced-code lines to blanks so a code fence
+    # never reads as prose, preserving line numbers, then scan spans (which may
+    # wrap across single newlines) over the masked stream.
+    in_fence = False
+    prose = []
+    for ln in text_lines:
+        if FENCE_RE.match(ln):
+            in_fence = not in_fence
+            prose.append("")
+        elif in_fence:
+            prose.append("")
+        else:
+            prose.append(ln)
+    text = "\n".join(prose)
+    starts = [0]
+    for ln in prose:
+        starts.append(starts[-1] + len(ln) + 1)
+
+    def lineno_of(off):
+        import bisect
+        return bisect.bisect_right(starts, off)
+
+    for m in SPAN_RE.finditer(text):
+        c = m.group(1)
+        if "\n\n" in c:
+            continue
+        c = re.sub(r"\s+", " ", c).strip()
+        ex.process_span(lineno_of(m.start()), c)
+
+    # Fenced-code identifiers and in-fence SHAs, plus spec references in prose.
+    in_fence = False
+    for lineno, ln in enumerate(text_lines, 1):
+        if FENCE_RE.match(ln):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            ln_code = re.sub(r"/\*.*?\*/", "", ln)      # comment words are not citations
+            ln_code = re.sub(r"//.*", "", ln_code)
+            num_spans = [(m.start(), m.end()) for m in NUM_RE.finditer(ln_code)]
+            for mm in IDENT_RE.finditer(ln_code):
+                t = mm.group(0)
+                if t in C_KEYWORDS:
+                    continue
+                if any(a <= mm.start() < b for a, b in num_spans):
+                    continue
+                if pattern_token(ln_code, mm.start(), mm.end()):
+                    ex.add(lineno, "illustrative", "placeholder", t, ln.strip(), True)
+                    continue
+                sub = "in-fence-local" if t in SNIPPET_LOCALS else "in-fence"
+                ex.add(lineno, "C2", sub, t, ln.strip(), True)
+            for mm in SHA_IN_TEXT.finditer(ln):
+                ex.add(lineno, "C3", "sha-in-fence", mm.group(0), ln.strip(), True)
+            continue
+        if ARM_CTX.search(ln):
+            for mm in SPEC_SECTION.finditer(ln):
+                ex.add(lineno, "C5", "spec-section", mm.group(0), ln.strip(), False)
+        for mm in SPEC_ANCHOR.finditer(ln):
+            ex.add(lineno, "C5", "spec-anchor", mm.group(0), ln.strip(), False)
+    return ex.rows
+
+
+# --------------------------------------------------------------------------
+# Decision: which citations are checked, and which are skipped.
+#
+# The bar for a check is near-zero false positives and real power: a check
+# that cannot fail because its token is everywhere adds nothing. So only
+# specific, kernel-namespaced citations are checked; architectural names,
+# placeholders, and generic tokens are skipped. A token occurring more than
+# GENERIC_THRESHOLD times cannot meaningfully fail an existence check.
+# --------------------------------------------------------------------------
+
+GENERIC_THRESHOLD = 100
+
+# Identifiers that appear only in worked examples and would otherwise read as
+# checkable symbols.
+EXAMPLE_LOCALS = {"captured_seq", "do_sve", "handle_hcall", "host_args", "local_args",
+                  "local_vcpu", "update_hyp_state", "vcpu_reset_args", "VALID_FLAG"}
+# Author shorthand for a longer symbol, and metavariables/concept labels.
+SKIP_SHORTHAND = {"MIN_PKVM", "PKVM_ONLY",   # __KVM_HOST_SMCCC_FUNC_MIN_PKVM etc.
+                  "VNCR_r",                  # VNCR(r) = __VNCR_START__ + VNCR_r/8
+                  "hyp_fixmap"}              # concept label; hyp_fixmap_map/_unmap are real
+SKIP_EXPLICIT = EXAMPLE_LOCALS | SKIP_SHORTHAND
+# Lowercase ISA / lock mnemonics cited in prose, not kernel symbols.
+SPEC_MNEMONIC = {"BnA", "DnI", "ERETA", "RVAE1IS", "S12E1R", "TBIDn",
+                 "TBNZ", "TBZ", "TRCIT", "eret", "irqsave"}
+# A bare file-type reference (`*.c`, `.sysreg`), not a specific path citation.
+TYPEREF_RE = re.compile(r"^\*?\.[a-z0-9]+$")
+
+
+def is_typeref(tok):
+    return bool(TYPEREF_RE.match(tok))
+
+
+def kernel_namespaced(tok):
+    """A checkable kernel symbol carries an underscore (kvm_id_reg_rw_mask,
+    ESR_ELx_IL, CONFIG_BUG) or is a lowercase identifier of four or more chars
+    (memcpy, finalize_pkvm). Anything else, all-caps or mixed-case with no
+    underscore, is an ARM ISA mnemonic, a register abbreviation, or a prose
+    word, and is left to prose review."""
+    if "_" in tok:
+        return True
+    return tok[0].islower() and len(tok) >= 4
+
+
+# --------------------------------------------------------------------------
+# Kernel tree: rev-parameterized git plumbing.
+# --------------------------------------------------------------------------
+
+CORPUS_EXCLUDE = ":(exclude)Documentation/"
+
+
+class KernelTree:
+    """Read-only access to a kernel tree through git plumbing.
+
+    Symbol lookups grep the working tree when --rev is the tree's own HEAD
+    (git keeps the files uncompressed on disk, so a fixed-string grep is fast),
+    and grep at the revision otherwise (correct for any release, but slower
+    because git decompresses tree objects on each query)."""
+
+    def __init__(self, path, rev="HEAD", jobs=12):
+        self.path = path
+        self.jobs = jobs
+        self.rev = self._rev_parse(rev)
+        self.head = self._rev_parse("HEAD")
+        self.at_head = self.rev == self.head
+        self._files = None
+
+    def _git(self, args, check=False):
+        r = subprocess.run(["git", "-C", self.path] + args,
+                           capture_output=True, encoding="utf-8", errors="replace")
+        if check and r.returncode != 0:
+            raise RuntimeError(f"git {' '.join(args)}: {r.stderr.strip()}")
+        return r
+
+    def _rev_parse(self, rev):
+        r = self._git(["rev-parse", "--verify", "-q", f"{rev}^{{commit}}"])
+        if r.returncode != 0:
+            raise SystemExit(f"check-drift.py: cannot resolve rev '{rev}' in {self.path}")
+        return r.stdout.strip()
+
+    def files(self):
+        """The set of tracked paths at the revision."""
+        if self._files is None:
+            out = self._git(["ls-tree", "-r", "--name-only", self.rev], check=True).stdout
+            self._files = set(out.splitlines())
+        return self._files
+
+    def resolve_path(self, token):
+        """(count, kind) for a path: exact, else directory, else unique suffix.
+        kind is 'exact', 'dir', 'suffix', or 'none'; count is the match count."""
+        s = token[2:] if token.startswith("./") else token
+        files = self.files()
+        if s in files:
+            return 1, "exact"
+        prefix = s.rstrip("/") + "/"                  # directory, with or without a slash
+        if any(f.startswith(prefix) for f in files):
+            return 1, "dir"
+        n = sum(1 for f in files if f == s or f.endswith("/" + s))
+        return n, ("suffix" if n else "none")
+
+    def symbol_counts(self, tokens):
+        """Map each token to its whole-word match-line count in the corpus
+        (the source tree with Documentation/ excluded), probed in parallel."""
+        def probe(tok):
+            args = ["grep", "-F", "-w", "-I", "-c", "-e", tok]
+            if not self.at_head:
+                args.append(self.rev)
+            args += ["--", CORPUS_EXCLUDE]
+            r = self._git(args)
+            total = 0
+            for line in r.stdout.splitlines():
+                m = re.search(r":(\d+)$", line)
+                if m:
+                    total += int(m.group(1))
+            return tok, total
+        with cf.ThreadPoolExecutor(max_workers=self.jobs) as ex:
+            return dict(ex.map(probe, tokens))
+
+    def commit_exists(self, sha):
+        return self._git(["cat-file", "-e", f"{sha}^{{commit}}"]).returncode == 0
+
+    def commit_subject(self, sha):
+        return self._git(["log", "-1", "--format=%s", sha]).stdout.strip()
+
+    def subject_count(self, subject):
+        r = self._git(["log", "--oneline", "--fixed-strings",
+                       f"--grep={subject}", self.rev])
+        return len([l for l in r.stdout.splitlines() if l.strip()])
+
+    def is_ancestor(self, older, newer):
+        return self._git(["merge-base", "--is-ancestor", older, newer]).returncode == 0
+
+
+# --------------------------------------------------------------------------
+# Verification footer (C4).
+# --------------------------------------------------------------------------
+
+FOOTER_MARKER = re.compile(r"<!--\s*drift-checked:")
+FOOTER_RE = re.compile(
+    r"<!--\s*drift-checked:\s*rev=([0-9a-fA-F]{12,40})\s+date=(\d{4}-\d{2}-\d{2})\s*-->")
+
+
+def parse_footer(text_lines):
+    """(rev, date, status, line) where status is 'ok' (valid footer), 'malformed'
+    (a drift-checked marker that does not parse), or 'absent'. line is the footer's
+    1-based line number, or 1 when absent."""
+    for idx in range(len(text_lines) - 1, -1, -1):
+        ln = text_lines[idx]
+        if not ln.strip():
+            continue
+        m = FOOTER_RE.search(ln)
+        if m:
+            return m.group(1), m.group(2), "ok", idx + 1
+        if FOOTER_MARKER.search(ln):
+            return None, None, "malformed", idx + 1
+        break
+    return None, None, "absent", 1
+
+
+# --------------------------------------------------------------------------
+# Checking a guide.
+# --------------------------------------------------------------------------
+
+Finding = namedtuple("Finding", "guide line check level message")
+
+
+def paragraph_of(text_lines):
+    """Map 1-based line number to a paragraph id (blank-line separated)."""
+    out = {}
+    pid = 0
+    prev_blank = True
+    for i, ln in enumerate(text_lines, 1):
+        if not ln.strip():
+            prev_blank = True
+            continue
+        if prev_blank:
+            pid += 1
+        prev_blank = False
+        out[i] = pid
+    return out
+
+
+def decide(cite, sym_hit, path_res):
+    """(decision, reason) for one citation. decision is 'check', 'skip', or
+    'ignore'; reason is a short tag, with reasons starting 'DRIFT' / 'gone' /
+    'ambiguous' marking a finding."""
+    cls, sub, tok = cite.cls, cite.sub, cite.token
+    if cls == "C1":
+        if is_typeref(tok):
+            return "skip", "path-typeref"
+        n, kind = path_res[tok]
+        if n == 0:
+            return "check", "gone-path"
+        if kind == "suffix" and n > 1:
+            return "check", "ambiguous-path"
+        return "check", "resolves"
+    if cls == "C3":
+        if sub == "sha-in-fence":
+            return "ignore", "example-sha"
+        return "check", "sha"
+    if cls == "C3b":
+        return "check", "subject"
+    if cls == "C5":
+        return "ignore", "spec"
+    if cls == "illustrative":
+        return "ignore", sub
+    if cls == "other":
+        return "ignore", "no-ident"
+    # C2 symbol.
+    hit = sym_hit.get(tok, 0)
+    if tok in SKIP_EXPLICIT or sub in ("in-fence-local", "snippet-local"):
+        return "skip", "example"
+    if sub == "register-or-field" or tok in SPEC_MNEMONIC:
+        return "skip", "spec-arch"
+    if not kernel_namespaced(tok):
+        return "skip", "spec-arch"
+    if hit == 0 and re.search(r"_EL[012x]", tok):
+        return "skip", "spec-arch"               # architectural register name
+    if hit >= GENERIC_THRESHOLD:
+        return "skip", "generic"
+    return "check", ("resolves" if hit > 0 else "DRIFT")
+
+
+def paired_path(cite, same_line_paths, para_paths, line_para):
+    """The single path cited alongside a symbol (same line, else the sole path
+    in its paragraph), or None."""
+    on_line = same_line_paths.get(cite.line)
+    if on_line and len(on_line) == 1:
+        return next(iter(on_line))
+    pp = line_para.get(cite.line)
+    inpara = para_paths.get(pp) if pp else None
+    if inpara and len(inpara) == 1:
+        return next(iter(inpara))
+    return None
+
+
+def check_guide(tree, path, text_lines, cites, sym_hit, opts):
+    """Findings for one guide whose citations are being checked."""
+    guide = os.path.basename(path)
+    findings = []
+    stats = Counter()
+
+    path_res = {}
+    for c in cites:
+        if c.cls == "C1" and not is_typeref(c.token):
+            path_res[c.token] = tree.resolve_path(c.token)
+
+    # Symbol<->path pairing, used only to name the cited file in a finding.
+    line_para = paragraph_of(text_lines)
+    same_line_paths = defaultdict(set)
+    para_paths = defaultdict(set)
+    for c in cites:
+        if c.cls != "C1":
+            continue
+        decision, reason = decide(c, sym_hit, path_res)
+        if decision == "check" and not reason.startswith(("gone", "ambiguous")):
+            same_line_paths[c.line].add(c.token)
+            pp = line_para.get(c.line)
+            if pp:
+                para_paths[pp].add(c.token)
+
+    for c in cites:
+        decision, reason = decide(c, sym_hit, path_res)
+        stats[(c.cls, decision)] += 1
+        if decision != "check":
+            continue
+        if c.cls == "C1":
+            if reason == "gone-path":
+                findings.append(Finding(guide, c.line, "C1", "error",
+                                        f"undefined path '{c.token}'"))
+            elif reason == "ambiguous-path":
+                findings.append(Finding(guide, c.line, "C1", "error",
+                                        f"ambiguous path fragment '{c.token}' "
+                                        f"({path_res[c.token][0]} matches)"))
+        elif c.cls == "C2":
+            if reason == "DRIFT":
+                near = paired_path(c, same_line_paths, para_paths, line_para)
+                msg = f"undefined symbol '{c.token}'"
+                if near:
+                    msg += f" (cited near {near})"
+                findings.append(Finding(guide, c.line, "C2", "error", msg))
+        elif c.cls == "C3":
+            if not tree.commit_exists(c.token):
+                findings.append(Finding(guide, c.line, "C3", "error",
+                                        f"unknown commit {c.token}"))
+            else:
+                quoted = adjacent_subject(paragraph_text(text_lines, c.line), c.token)
+                if quoted:
+                    have = tree.commit_subject(c.token)
+                    if have != quoted:
+                        findings.append(Finding(guide, c.line, "C3", "error",
+                                        f"commit {c.token} subject changed: "
+                                        f'guide "{quoted}" tree "{have}"'))
+        elif c.cls == "C3b":
+            if tree.subject_count(c.token) == 0:
+                findings.append(Finding(guide, c.line, "C3", "error",
+                                        f'no commit matches subject "{c.token}"'))
+    return findings, stats
+
+
+def adjacent_subject(context, sha):
+    """The quoted subject in the immediately-adjacent `<sha> ("subject")`
+    idiom, else None. The guides also quote commit bodies further along the
+    sentence, so the parenthesised quote must follow the sha directly (only a
+    closing backtick and spaces between)."""
+    m = re.search(re.escape(sha) + r'[`\s]*\(\s*"([^"]+)"', context)
+    return m.group(1) if m else None
+
+
+def paragraph_text(text_lines, lineno):
+    """The blank-line-delimited paragraph containing a 1-based line, joined and
+    whitespace-collapsed, so a citation that wraps across lines reads as one."""
+    lo = hi = lineno - 1
+    while lo > 0 and text_lines[lo - 1].strip():
+        lo -= 1
+    while hi + 1 < len(text_lines) and text_lines[hi + 1].strip():
+        hi += 1
+    return re.sub(r"\s+", " ", " ".join(text_lines[lo:hi + 1]))
+
+
+def check_footer(tree, guide, text_lines, opts):
+    """Footer findings and whether the guide's citations should be checked."""
+    findings = []
+    rev, fdate, status, fline = parse_footer(text_lines)
+    if status == "ok":
+        if not tree.commit_exists(rev):
+            findings.append(Finding(guide, fline, "C4", "error",
+                                    f"footer rev {rev} does not resolve"))
+        elif not tree.is_ancestor(rev, tree.rev):
+            findings.append(Finding(guide, fline, "C4", "error",
+                                    f"footer rev {rev} is not an ancestor of "
+                                    f"{tree.rev[:12]}"))
+        try:
+            age = (date.today() - date.fromisoformat(fdate)).days
+            if age > 90:
+                findings.append(Finding(guide, fline, "C4", "warn",
+                                        f"footer dated {fdate} is {age} days old"))
+        except ValueError:
+            findings.append(Finding(guide, fline, "C4", "error",
+                                    f"footer date '{fdate}' is not YYYY-MM-DD"))
+        return findings, True
+    if status == "malformed":
+        findings.append(Finding(guide, fline, "C4", "error",
+                                "malformed drift-checked footer"))
+        return findings, opts.all
+    # absent
+    if opts.require_footer:
+        findings.append(Finding(guide, 1, "C4", "error", "no drift-checked footer"))
+        return findings, False
+    if opts.all:
+        return findings, True
+    findings.append(Finding(guide, 1, "C4", "info",
+                            "not onboarded (no drift-checked footer); skipped"))
+    return findings, False
+
+
+def load_spec_index(path):
+    if not path:
+        return None
+    with open(path) as f:
+        return {ln.strip() for ln in f if ln.strip() and not ln.startswith("#")}
+
+
+def run(tree, guides, opts):
+    """Check every guide; return (findings, stats). Symbol lookups for all
+    guides are batched into one probe pass."""
+    per_guide = []
+    footer_findings = []
+    spec_index = load_spec_index(opts.spec_index)
+    for path in guides:
+        guide = os.path.basename(path)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+        ff, do_check = check_footer(tree, guide, lines, opts)
+        footer_findings += ff
+        if do_check:
+            per_guide.append((path, lines, extract_citations(lines, guide)))
+
+    sym_tokens = sorted({c.token for _, _, cites in per_guide
+                         for c in cites if c.cls == "C2"})
+    sym_hit = tree.symbol_counts(sym_tokens) if sym_tokens else {}
+
+    findings = list(footer_findings)
+    stats = Counter()
+    for path, lines, cites in per_guide:
+        gf, gs = check_guide(tree, path, lines, cites, sym_hit, opts)
+        findings += gf
+        stats += gs
+        if spec_index is not None:
+            guide = os.path.basename(path)
+            for c in cites:
+                if c.cls == "C5" and c.token not in spec_index:
+                    findings.append(Finding(guide, c.line, "C5", "warn",
+                                    f"unknown spec reference '{c.token}'"))
+    return findings, stats
+
+
+# --------------------------------------------------------------------------
+# Reporting.
+# --------------------------------------------------------------------------
+
+def report(findings, stats, opts):
+    errors = 0
+    for f in sorted(findings, key=lambda f: (f.level != "error", f.guide, f.line)):
+        line = f"{f.guide}:{f.line}: {f.check}: {f.message}"
+        if f.level == "error":
+            errors += 1
+            print(line)
+        elif f.level == "warn":
+            print(f"{f.guide}:{f.line}: {f.check}: warning: {f.message}")
+        else:
+            print(line, file=sys.stderr)
+    if opts.stats:
+        print_stats(stats)
+    return errors
+
+
+def print_stats(stats):
+    classes = ["C1", "C2", "C3", "C3b", "C5", "illustrative", "other"]
+    checked = Counter()
+    skipped = Counter()
+    ignored = Counter()
+    for (cls, decision), n in stats.items():
+        {"check": checked, "skip": skipped, "ignore": ignored}[decision][cls] += n
+    print(f"\n  {'citations':13}{'checked':>8}{'skipped':>9}{'ignored':>9}",
+          file=sys.stderr)
+    for cls in classes:
+        if checked[cls] or skipped[cls] or ignored[cls]:
+            print(f"  {cls:13}{checked[cls]:>8}{skipped[cls]:>9}{ignored[cls]:>9}",
+                  file=sys.stderr)
+    print(f"  {'total':13}{sum(checked.values()):>8}{sum(skipped.values()):>9}"
+          f"{sum(ignored.values()):>9}", file=sys.stderr)
+
+
+# --------------------------------------------------------------------------
+# Self-test: build a tiny kernel-shaped repo in a tempdir and exercise each
+# check's pass and fail path, so the checker is testable without a kernel tree.
+# --------------------------------------------------------------------------
+
+def selftest():
+    Opts = namedtuple("Opts", "all require_footer stats spec_index")
+
+    with tempfile.TemporaryDirectory() as d:
+        repo = os.path.join(d, "linux")
+        os.makedirs(os.path.join(repo, "mm"))
+        os.makedirs(os.path.join(repo, "Documentation"))
+        with open(os.path.join(repo, "mm", "good.c"), "w") as f:
+            f.write("int live_helper(void) { return 0; }\n"
+                    "struct memslot_map { int member; };\n")
+        with open(os.path.join(repo, "mm", "other.c"), "w") as f:
+            f.write("void unrelated(void) {}\n")
+        with open(os.path.join(repo, "Documentation", "note.rst"), "w") as f:
+            f.write("The doc_only_symbol lives only here.\n")
+        env = dict(os.environ, GIT_AUTHOR_NAME="t", GIT_AUTHOR_EMAIL="t@t",
+                   GIT_COMMITTER_NAME="t", GIT_COMMITTER_EMAIL="t@t")
+        for args in (["init", "-q"], ["add", "-A"],
+                     ["commit", "-q", "-m", "kvm: add live_helper for the memslot map"]):
+            subprocess.run(["git", "-C", repo] + args, check=True, env=env)
+        sha = subprocess.run(["git", "-C", repo, "rev-parse", "HEAD"],
+                             capture_output=True, text=True).stdout.strip()
+        tree = KernelTree(repo)
+        opts = Opts(all=True, require_footer=False, stats=False, spec_index=None)
+
+        def findings_for(body):
+            gp = os.path.join(d, "guide.md")
+            with open(gp, "w") as fh:
+                fh.write(body)
+            found, _ = run(tree, [gp], opts)
+            return {(x.check, x.level, x.message) for x in found}
+
+        checks = []
+
+        def want(name, got, must_have, must_not):
+            ok = all(m in got for m in must_have) and all(m not in got for m in must_not)
+            checks.append((name, ok, got))
+
+        # C1: valid exact path, valid suffix fragment, and a gone path.
+        got = findings_for("`mm/good.c` and `good.c` exist, `mm/gone.c` does not.\n")
+        want("C1 gone", got,
+             [("C1", "error", "undefined path 'mm/gone.c'")],
+             [("C1", "error", "undefined path 'mm/good.c'"),
+              ("C1", "error", "undefined path 'good.c'")])
+
+        # C2: a live symbol resolves, a vanished one is a finding, a symbol that
+        # survives only under Documentation/ is a finding (corpus excludes it).
+        got = findings_for("`live_helper` is fine, `vanished_helper` is gone, "
+                           "`doc_only_symbol` only in docs.\n")
+        want("C2 gone", got,
+             [("C2", "error", "undefined symbol 'vanished_helper'"),
+              ("C2", "error", "undefined symbol 'doc_only_symbol'")],
+             [("C2", "error", "undefined symbol 'live_helper'")])
+
+        # A live symbol cited beside an unrelated file is not a finding:
+        # existence is tree-wide, and a same-paragraph path is a coincidence,
+        # not a containment claim, so scoping to it would be a false positive.
+        got = findings_for("The helper `live_helper` is mentioned near `mm/other.c`.\n")
+        want("C2 tree-wide (no paired-file FP)", got, [],
+             [("C2", "error", "undefined symbol 'live_helper'")])
+
+        # C3: a resolving SHA with an unchanged subject, and a bogus SHA.
+        got = findings_for(f"See `{sha}` and `deadbeefdeadbeef`.\n")
+        want("C3 sha", got,
+             [("C3", "error", "unknown commit deadbeefdeadbeef")],
+             [("C3", "error", f"unknown commit {sha}")])
+
+        # C3 subject compare: adjacent quoted subject that no longer matches.
+        got = findings_for(f'Commit `{sha}` ("kvm: renamed subject").\n')
+        want("C3 subject-mismatch", got,
+             [("C3", "error", f'commit {sha} subject changed: '
+               f'guide "kvm: renamed subject" '
+               f'tree "kvm: add live_helper for the memslot map"')],
+             [])
+
+        # C3b: a backticked commit subject resolved by substring.
+        got = findings_for("`KVM: arm64: nonexistent subject line here`\n")
+        want("C3b subject-gone", got,
+             [("C3", "error", 'no commit matches subject '
+               '"KVM: arm64: nonexistent subject line here"')],
+             [])
+
+        # C4: footer absent (default skip / --require-footer error) and stale.
+        Opts0 = Opts(all=False, require_footer=False, stats=False, spec_index=None)
+        f0, _ = run(tree, [_write(d, "`vanished_helper`\n")], Opts0)
+        want("C4 no-footer skip", {(x.check, x.level, x.message) for x in f0},
+             [("C4", "info", "not onboarded (no drift-checked footer); skipped")],
+             [("C2", "error", "undefined symbol 'vanished_helper'")])
+
+        Optsr = Opts(all=False, require_footer=True, stats=False, spec_index=None)
+        fr, _ = run(tree, [_write(d, "`vanished_helper`\n")], Optsr)
+        want("C4 require-footer", {(x.check, x.level, x.message) for x in fr},
+             [("C4", "error", "no drift-checked footer")], [])
+
+        good_footer = f"body\n\n<!-- drift-checked: rev={sha} date=2000-01-01 -->\n"
+        fg, _ = run(tree, [_write(d, good_footer)], Opts0)
+        want("C4 stale-footer", {(x.check, x.level, x.message) for x in fg},
+             [("C4", "warn", "footer dated 2000-01-01 is "
+               f"{(date.today() - date(2000, 1, 1)).days} days old")],
+             [("C4", "info", "not onboarded (no drift-checked footer); skipped")])
+
+        bad_rev = "body\n\n<!-- drift-checked: rev=000000000000 date=2099-01-01 -->\n"
+        fb, _ = run(tree, [_write(d, bad_rev)], Opts0)
+        want("C4 bad-rev", {(x.check, x.level, x.message) for x in fb},
+             [("C4", "error", "footer rev 000000000000 does not resolve")], [])
+
+        malformed = "body\n\n<!-- drift-checked: rev=xyz -->\n"
+        fm, _ = run(tree, [_write(d, malformed)], Opts0)
+        want("C4 malformed", {(x.check, x.level, x.message) for x in fm},
+             [("C4", "error", "malformed drift-checked footer")], [])
+
+    ok = True
+    for name, passed, got in checks:
+        print(f"  {'ok  ' if passed else 'FAIL'}  {name}")
+        if not passed:
+            ok = False
+            for g in sorted(got):
+                print(f"          got: {g}")
+    print("selftest:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+def _write(d, body):
+    gp = os.path.join(d, f"g{abs(hash(body)) % 10000}.md")
+    with open(gp, "w") as f:
+        f.write(body)
+    return gp
+
+
+# --------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(description="Report stale citations in the "
+                                 "subsystem guides against a kernel tree.")
+    ap.add_argument("guides", nargs="*", help="guide markdown files to check")
+    ap.add_argument("--tree", help="path to a local kernel git tree")
+    ap.add_argument("--rev", default="HEAD",
+                    help="revision to check against (default: the tree's HEAD)")
+    ap.add_argument("--all", action="store_true",
+                    help="check a guide's citations even without a footer")
+    ap.add_argument("--require-footer", action="store_true",
+                    help="treat a missing footer as an error")
+    ap.add_argument("--stats", action="store_true",
+                    help="print per-class checked/skipped/ignored counts")
+    ap.add_argument("--spec-index",
+                    help="file of known spec references to validate C5 against")
+    ap.add_argument("--jobs", type=int, default=12, help="parallel grep workers")
+    ap.add_argument("--selftest", action="store_true",
+                    help="run the built-in self-test (needs no kernel tree)")
+    opts = ap.parse_args()
+
+    if opts.selftest:
+        return selftest()
+    if not opts.tree or not opts.guides:
+        ap.error("--tree and at least one guide are required")
+
+    tree = KernelTree(opts.tree, opts.rev, opts.jobs)
+    findings, stats = run(tree, opts.guides, opts)
+    errors = report(findings, stats, opts)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kernel/scripts/check-drift.py
+++ b/kernel/scripts/check-drift.py
@@ -389,9 +389,12 @@ class KernelTree:
         return self._git(["log", "-1", "--format=%s", sha]).stdout.strip()
 
     def subject_count(self, subject):
-        r = self._git(["log", "--oneline", "--fixed-strings",
-                       f"--grep={subject}", self.rev])
-        return len([l for l in r.stdout.splitlines() if l.strip()])
+        """Commits in --rev's history whose SUBJECT contains the string. --grep
+        (a whole-message match) is a cheap prefilter; the subject-only filter
+        keeps a citation from validating against an unrelated commit's body."""
+        r = self._git(["log", "--fixed-strings", f"--grep={subject}",
+                       "--format=%s", self.rev])
+        return sum(1 for s in r.stdout.splitlines() if subject in s)
 
     def is_ancestor(self, older, newer):
         return self._git(["merge-base", "--is-ancestor", older, newer]).returncode == 0
@@ -549,6 +552,10 @@ def check_guide(tree, path, text_lines, cites, sym_hit, opts):
             if not tree.commit_exists(c.token):
                 findings.append(Finding(guide, c.line, "C3", "error",
                                         f"unknown commit {c.token}"))
+            elif not tree.is_ancestor(c.token, tree.rev):
+                findings.append(Finding(guide, c.line, "C3", "error",
+                                        f"commit {c.token} not in history of "
+                                        f"{tree.rev[:12]}"))
             else:
                 quoted = adjacent_subject(paragraph_text(text_lines, c.line), c.token)
                 if quoted:
@@ -724,7 +731,17 @@ def selftest():
             subprocess.run(["git", "-C", repo] + args, check=True, env=env)
         sha = subprocess.run(["git", "-C", repo, "rev-parse", "HEAD"],
                              capture_output=True, text=True).stdout.strip()
+        # A later commit whose body mentions a commit-subject-shaped phrase absent
+        # from its own subject: exercises the C3b subject-only match, and being
+        # outside the first commit's history, the C3 ancestry scope.
+        subprocess.run(["git", "-C", repo, "commit", "-q", "--allow-empty",
+                        "-m", "KVM: arm64: real subject present\n\n"
+                        "Body text mentions KVM: arm64: body-only phrase here."],
+                       check=True, env=env)
+        sha2 = subprocess.run(["git", "-C", repo, "rev-parse", "HEAD"],
+                              capture_output=True, text=True).stdout.strip()
         tree = KernelTree(repo)
+        tree_old = KernelTree(repo, rev=sha)
         opts = Opts(all=True, require_footer=False, stats=False, spec_index=None)
 
         def findings_for(body):
@@ -783,6 +800,31 @@ def selftest():
              [("C3", "error", 'no commit matches subject '
                '"KVM: arm64: nonexistent subject line here"')],
              [])
+
+        # C3b subject-only: a commit-subject-shaped phrase present only in a
+        # commit BODY is a finding (--grep matches the body, the subject-only
+        # filter rejects it); the actual subject resolves.
+        got = findings_for("`KVM: arm64: body-only phrase here`\n")
+        want("C3b body-only rejected", got,
+             [("C3", "error", 'no commit matches subject '
+               '"KVM: arm64: body-only phrase here"')], [])
+        got = findings_for("`KVM: arm64: real subject present`\n")
+        want("C3b real subject resolves", got, [],
+             [("C3", "error", 'no commit matches subject '
+               '"KVM: arm64: real subject present"')])
+
+        # C3 ancestry: a valid commit outside the checked rev's history is a
+        # finding; the rev's own commit is not (a commit is its own ancestor).
+        def findings_at(tree_x, body):
+            gp = os.path.join(d, "guide.md")
+            with open(gp, "w") as fh:
+                fh.write(body)
+            found, _ = run(tree_x, [gp], opts)
+            return {(x.check, x.level, x.message) for x in found}
+        want("C3 not-in-history", findings_at(tree_old, f"See `{sha2}`.\n"),
+             [("C3", "error", f"commit {sha2} not in history of {sha[:12]}")], [])
+        want("C3 in-history self", findings_at(tree_old, f"See `{sha}`.\n"),
+             [], [("C3", "error", f"commit {sha} not in history of {sha[:12]}")])
 
         # C4: footer absent (default skip / --require-footer error) and stale.
         Opts0 = Opts(all=False, require_footer=False, stats=False, spec_index=None)

--- a/kernel/scripts/check-drift.py
+++ b/kernel/scripts/check-drift.py
@@ -391,6 +391,8 @@ class KernelTree:
         self.rev = self._rev_parse(rev)
         self.head = self._rev_parse("HEAD")
         self.at_head = self.rev == self.head
+        self.shallow = (self._git(["rev-parse", "--is-shallow-repository"])
+                        .stdout.strip() == "true")
         self._files = None
 
     def _git(self, args, check=False):
@@ -511,10 +513,12 @@ def paragraph_of(text_lines):
     return out
 
 
-def decide(cite, sym_hit, path_res):
+def decide(cite, sym_hit, path_res, shallow=False):
     """(decision, reason) for one citation. decision is 'check', 'skip', or
     'ignore'; reason is a short tag, with reasons starting 'DRIFT' / 'gone' /
-    'ambiguous' marking a finding."""
+    'ambiguous' marking a finding. On a shallow tree the commit-history checks
+    (C3, C3b) are skipped: their git plumbing needs history the tree omits, and
+    a missing object would otherwise read as a broken citation."""
     cls, sub, tok = cite.cls, cite.sub, cite.token
     if cls == "C1":
         if sub == "repo-internal":               # verified against the prompts repo, not the kernel
@@ -532,9 +536,9 @@ def decide(cite, sym_hit, path_res):
     if cls == "C3":
         if sub == "sha-in-fence":
             return "ignore", "example-sha"
-        return "check", "sha"
+        return ("skip", "shallow-history") if shallow else ("check", "sha")
     if cls == "C3b":
-        return "check", "subject"
+        return ("skip", "shallow-history") if shallow else ("check", "subject")
     if cls == "C5":
         return "ignore", "spec"
     if cls == "illustrative":
@@ -597,7 +601,7 @@ def check_guide(tree, path, text_lines, cites, sym_hit, opts, repo_files=frozens
     for c in cites:
         if c.cls != "C1" or c.sub == "repo-internal":
             continue
-        decision, reason = decide(c, sym_hit, path_res)
+        decision, reason = decide(c, sym_hit, path_res, tree.shallow)
         if decision == "check" and not reason.startswith(("gone", "ambiguous")):
             same_line_paths[c.line].add(c.token)
             pp = line_para.get(c.line)
@@ -605,7 +609,7 @@ def check_guide(tree, path, text_lines, cites, sym_hit, opts, repo_files=frozens
                 para_paths[pp].add(c.token)
 
     for c in cites:
-        decision, reason = decide(c, sym_hit, path_res)
+        decision, reason = decide(c, sym_hit, path_res, tree.shallow)
         stats[(c.cls, decision)] += 1
         if decision != "check":
             continue
@@ -680,13 +684,14 @@ def check_footer(tree, guide, text_lines, opts):
     findings = []
     rev, fdate, status, fline = parse_footer(text_lines)
     if status == "ok":
-        if not tree.commit_exists(rev):
-            findings.append(Finding(guide, fline, "C4", "error",
-                                    f"footer rev {rev} does not resolve"))
-        elif not tree.is_ancestor(rev, tree.rev):
-            findings.append(Finding(guide, fline, "C4", "error",
-                                    f"footer rev {rev} is not an ancestor of "
-                                    f"{tree.rev[:12]}"))
+        if not tree.shallow:                          # ancestry needs history
+            if not tree.commit_exists(rev):
+                findings.append(Finding(guide, fline, "C4", "error",
+                                        f"footer rev {rev} does not resolve"))
+            elif not tree.is_ancestor(rev, tree.rev):
+                findings.append(Finding(guide, fline, "C4", "error",
+                                        f"footer rev {rev} is not an ancestor of "
+                                        f"{tree.rev[:12]}"))
         try:
             age = (date.today() - date.fromisoformat(fdate)).days
             if age > 90:
@@ -1032,6 +1037,42 @@ def selftest():
         want("C4 malformed", {(x.check, x.level, x.message) for x in fm},
              [("C4", "error", "malformed drift-checked footer")], [])
 
+        # Shallow tree (a depth-1 CI clone): the commit-history checks omit their
+        # git plumbing rather than false-flag citations whose history is absent,
+        # while path and symbol checks, which read only the tip, still run.
+        shallow = os.path.join(d, "shallow")
+        subprocess.run(["git", "clone", "-q", "--depth", "1", f"file://{repo}",
+                        shallow], check=True, env=env)
+        tree_sh = KernelTree(shallow)
+        assert tree_sh.shallow
+
+        def findings_sh(tree_x, body, o=opts):
+            gp = os.path.join(d, "guide.md")
+            with open(gp, "w") as fh:
+                fh.write(body)
+            found, _ = run(tree_x, [gp], o)
+            return {(x.check, x.level, x.message) for x in found}
+
+        want("shallow skips C3, keeps C1/C2",
+             findings_sh(tree_sh, "`deadbeefdeadbeef`, gone `mm/nope.c`, "
+                         "gone `vanished_helper`.\n"),
+             [("C1", "error", "undefined path 'mm/nope.c'"),
+              ("C2", "error", "undefined symbol 'vanished_helper'")],
+             [("C3", "error", "unknown commit deadbeefdeadbeef")])
+        want("shallow skips C3b",
+             findings_sh(tree_sh, "`KVM: arm64: nonexistent subject line here`\n"),
+             [], [("C3", "error", 'no commit matches subject '
+                   '"KVM: arm64: nonexistent subject line here"')])
+        # A footer whose rev is outside the shallow history: no false rev error,
+        # and the age warning still fires.
+        want("shallow footer keeps age, skips ancestry",
+             findings_sh(tree_sh,
+                         "body\n\n<!-- drift-checked: rev=000000000000 "
+                         "date=2000-01-01 -->\n", Opts0),
+             [("C4", "warn", "footer dated 2000-01-01 is "
+               f"{(date.today() - date(2000, 1, 1)).days} days old")],
+             [("C4", "error", "footer rev 000000000000 does not resolve")])
+
     ok = True
     for name, passed, got in checks:
         print(f"  {'ok  ' if passed else 'FAIL'}  {name}")
@@ -1078,6 +1119,9 @@ def main():
         ap.error("--tree and at least one guide are required")
 
     tree = KernelTree(opts.tree, opts.rev, opts.jobs)
+    if tree.shallow:
+        print("check-drift.py: shallow kernel tree; commit-history checks "
+              "(C3 commit citations, footer ancestry) skipped", file=sys.stderr)
     findings, stats = run(tree, opts.guides, opts)
     errors = report(findings, stats, opts)
     return 1 if errors else 0

--- a/kernel/scripts/check-drift.py
+++ b/kernel/scripts/check-drift.py
@@ -65,7 +65,23 @@ META = re.compile(r"<[A-Za-z0-9_|,.]+>")             # <REG>, <cc>, <n>, <0|1>
 BRACE_EXPANSION = re.compile(r"\{[^}]*[,|][^}]*\}")   # {0,1}, {I,F}
 MD_REF = re.compile(r"^[A-Za-z0-9._-]+\.md$")         # guide-internal reference
 
+# The kernel tree's top-level directories. An extensionless slashed token is a
+# real path only under one of these; a bare `foo/end` or `gpio/` is not.
+KNOWN_TOPDIRS = {"arch", "block", "certs", "crypto", "drivers", "Documentation",
+                 "fs", "include", "init", "io_uring", "ipc", "kernel", "lib",
+                 "mm", "net", "rust", "samples", "scripts", "security", "sound",
+                 "tools", "usr", "virt"}
+
 Cite = namedtuple("Cite", "guide line cls sub token raw in_fence")
+
+
+def is_repo_internal(s):
+    """A reference into the review-prompts repo (a sibling guide, an agent
+    prompt, a repo-relative path), which is verified against that repo, not the
+    kernel tree. A bare `.md` extension is a file-type reference, not a target."""
+    return (bool(re.search(r"[A-Za-z0-9_-]\.md$", s))
+            or s.startswith("../")
+            or s.startswith("review-prompts/"))
 
 
 def is_commit_subject(c):
@@ -83,12 +99,15 @@ def is_path(c):
     s = c.strip()
     if s.startswith("<") or " " in s or s.startswith("http"):
         return False
-    if s.endswith("/"):
-        return "/" in s.rstrip("/") + "/"
+    if s.startswith("/"):                             # absolute runtime path (/proc, /sys, /dev)
+        return False
+    if s.endswith("/"):                               # directory
+        body = s.rstrip("/")
+        return "/" in body or body in KNOWN_TOPDIRS
     if SRC_EXT.search(s):
         return True
     if "/" in s and re.search(r"/[a-z][a-z0-9_.-]*$", s):
-        return True
+        return s.split("/", 1)[0] in KNOWN_TOPDIRS    # extensionless path only under a real top dir
     return False
 
 
@@ -144,6 +163,9 @@ class Extractor:
         if pattern_token(c, m.start(), m.end()):
             self.add(lineno, "illustrative", "placeholder", t, c, False)
             return
+        if m.start() > 0 and c[m.start() - 1].isdigit():   # tail of a digit-led name (8250_dwlib)
+            self.add(lineno, "illustrative", "fragment", t, c, False)
+            return
         if t.startswith("CONFIG_"):
             self.add(lineno, "C2", "config", t, c, False)
         elif t.startswith("FEAT_"):
@@ -165,8 +187,16 @@ class Extractor:
         if is_commit_subject(c):
             self.add(lineno, "C3b", "commit-subject", c.strip(), c, False)
             return
-        if MD_REF.match(c.strip()):
-            self.add(lineno, "C1", "repo-internal", c.strip(), c, False)
+        s = c.strip()
+        if is_repo_internal(s):                       # sibling guide / agent prompt / repo path
+            self.add(lineno, "C1", "repo-internal", s, c, False)
+            return
+        if s.startswith("/"):                         # absolute runtime path, not a source citation
+            self.add(lineno, "illustrative", "abs-path", s, c, False)
+            return
+        if (is_path(c) or "/" in s) and (re.search(r"[*,]", s) or "->" in s
+                                         or looks_placeholder(s)):  # glob / metavariable path
+            self.add(lineno, "illustrative", "pattern-path", s, c, False)
             return
         if is_path(c):
             s = c.strip()
@@ -252,6 +282,9 @@ def extract_citations(text_lines, guide):
                 if pattern_token(ln_code, mm.start(), mm.end()):
                     ex.add(lineno, "illustrative", "placeholder", t, ln.strip(), True)
                     continue
+                if mm.start() > 0 and ln_code[mm.start() - 1].isdigit():
+                    ex.add(lineno, "illustrative", "fragment", t, ln.strip(), True)
+                    continue
                 sub = "in-fence-local" if t in SNIPPET_LOCALS else "in-fence"
                 ex.add(lineno, "C2", sub, t, ln.strip(), True)
             for mm in SHA_IN_TEXT.finditer(ln):
@@ -291,6 +324,35 @@ SPEC_MNEMONIC = {"BnA", "DnI", "ERETA", "RVAE1IS", "S12E1R", "TBIDn",
                  "TBNZ", "TBZ", "TRCIT", "eret", "irqsave"}
 # A bare file-type reference (`*.c`, `.sysreg`), not a specific path citation.
 TYPEREF_RE = re.compile(r"^\*?\.[a-z0-9]+$")
+# Metasyntactic placeholder components used in worked examples across the guides
+# (`my_free`, `foo_pm_ops`, `alloc_thing`, `SOME_SUBSYSTEM`). A conventional
+# stand-in, never a real kernel symbol.
+METASYNTACTIC = {"foo", "bar", "baz", "qux", "quux", "my", "some", "thing",
+                 "things", "wrapper", "dummy", "example", "frob", "blah", "mine"}
+# The guide names an absent symbol precisely to document its removal.
+REMOVED_WORD = re.compile(r"\b(removed|renamed|replaced|deleted|gone)\b")
+
+
+def is_metasyntactic(tok):
+    return any(part.lower() in METASYNTACTIC for part in tok.split("_"))
+
+
+def documents_removal(context, tok):
+    """True when the guide's own sentence says this token is gone, so flagging
+    it as undefined would be reporting a removal the author is documenting on
+    purpose (only ever consulted for an already-absent token). The removal word
+    must take the token as its subject (`X is removed`, `X ... have been
+    removed`), not merely appear nearby: `add_to_swap() ... remains until
+    explicitly removed` describes the folio, not the function."""
+    esc = re.escape(tok)
+    context = context.replace("`", " ")               # markdown emphasis is not prose
+    return bool(re.search(esc + r"[\s,()]*(\w+[,]?\s+){0,6}"
+                          r"(is|are|was|were|has been|have been|been)\s+"
+                          + REMOVED_WORD.pattern, context)
+                or re.search(r"\b(is|are) no\b[^.]{0,45}" + esc, context)
+                or re.search(r"\bno (function|symbol|macro|helper|field|member|such)"
+                             r"[^.]{0,45}" + esc, context)
+                or re.search(esc + r"[^.]{0,45}no longer\b", context))
 
 
 def is_typeref(tok):
@@ -455,12 +517,16 @@ def decide(cite, sym_hit, path_res):
     'ambiguous' marking a finding."""
     cls, sub, tok = cite.cls, cite.sub, cite.token
     if cls == "C1":
+        if sub == "repo-internal":               # verified against the prompts repo, not the kernel
+            return "check", "repo-ref"
         if is_typeref(tok):
             return "skip", "path-typeref"
         n, kind = path_res[tok]
         if n == 0:
             return "check", "gone-path"
         if kind == "suffix" and n > 1:
+            if "/" not in tok:                   # a bare basename matching several files still exists
+                return "skip", "ambiguous-basename"
             return "check", "ambiguous-path"
         return "check", "resolves"
     if cls == "C3":
@@ -487,7 +553,17 @@ def decide(cite, sym_hit, path_res):
         return "skip", "spec-arch"               # architectural register name
     if hit >= GENERIC_THRESHOLD:
         return "skip", "generic"
-    return "check", ("resolves" if hit > 0 else "DRIFT")
+    if hit > 0:
+        return "check", "resolves"
+    # hit == 0 would be a DRIFT finding; a resolving token is real, so these
+    # false-positive shapes are only suppressed here, never for a live symbol.
+    if re.match(r"^_[^_]", tok) or re.search(r"[^_]_$", tok):
+        return "skip", "fragment"                # prefix/suffix stub: _scoped, QCM_, _WRITE
+    if re.fullmatch(r"[a-z0-9_]*[NX][a-z0-9_]*", tok) and re.search(r"[a-z][NX]", tok):
+        return "skip", "metavar"                 # family placeholder: __raw_readN, pXd_mkspecial
+    if is_metasyntactic(tok):
+        return "skip", "example"                 # metasyntactic stand-in: foo_pm_ops, alloc_thing
+    return "check", "DRIFT"
 
 
 def paired_path(cite, same_line_paths, para_paths, line_para):
@@ -503,7 +579,7 @@ def paired_path(cite, same_line_paths, para_paths, line_para):
     return None
 
 
-def check_guide(tree, path, text_lines, cites, sym_hit, opts):
+def check_guide(tree, path, text_lines, cites, sym_hit, opts, repo_files=frozenset()):
     """Findings for one guide whose citations are being checked."""
     guide = os.path.basename(path)
     findings = []
@@ -511,7 +587,7 @@ def check_guide(tree, path, text_lines, cites, sym_hit, opts):
 
     path_res = {}
     for c in cites:
-        if c.cls == "C1" and not is_typeref(c.token):
+        if c.cls == "C1" and c.sub != "repo-internal" and not is_typeref(c.token):
             path_res[c.token] = tree.resolve_path(c.token)
 
     # Symbol<->path pairing, used only to name the cited file in a finding.
@@ -519,7 +595,7 @@ def check_guide(tree, path, text_lines, cites, sym_hit, opts):
     same_line_paths = defaultdict(set)
     para_paths = defaultdict(set)
     for c in cites:
-        if c.cls != "C1":
+        if c.cls != "C1" or c.sub == "repo-internal":
             continue
         decision, reason = decide(c, sym_hit, path_res)
         if decision == "check" and not reason.startswith(("gone", "ambiguous")):
@@ -534,7 +610,11 @@ def check_guide(tree, path, text_lines, cites, sym_hit, opts):
         if decision != "check":
             continue
         if c.cls == "C1":
-            if reason == "gone-path":
+            if reason == "repo-ref":
+                if not repo_resolves(c.token, repo_files):
+                    findings.append(Finding(guide, c.line, "C1", "error",
+                                            f"unresolved guide reference '{c.token}'"))
+            elif reason == "gone-path":
                 findings.append(Finding(guide, c.line, "C1", "error",
                                         f"undefined path '{c.token}'"))
             elif reason == "ambiguous-path":
@@ -543,6 +623,10 @@ def check_guide(tree, path, text_lines, cites, sym_hit, opts):
                                         f"({path_res[c.token][0]} matches)"))
         elif c.cls == "C2":
             if reason == "DRIFT":
+                if documents_removal(paragraph_text(text_lines, c.line), c.token):
+                    stats[(c.cls, "check")] -= 1     # the guide documents this removal on purpose
+                    stats[(c.cls, "skip")] += 1
+                    continue
                 near = paired_path(c, same_line_paths, para_paths, line_para)
                 msg = f"undefined symbol '{c.token}'"
                 if near:
@@ -634,12 +718,49 @@ def load_spec_index(path):
         return {ln.strip() for ln in f if ln.strip() and not ln.startswith("#")}
 
 
+def repo_file_set(guide_path):
+    """The set of files in the prompts repo containing the guide, for resolving
+    repo-internal references. Uses git if the guide is tracked, else walks the
+    enclosing tree."""
+    d = os.path.dirname(os.path.abspath(guide_path)) or "."
+    r = subprocess.run(["git", "-C", d, "rev-parse", "--show-toplevel"],
+                       capture_output=True, encoding="utf-8", errors="replace")
+    if r.returncode == 0:
+        root = r.stdout.strip()
+        files = subprocess.run(["git", "-C", root, "ls-files"],
+                               capture_output=True, encoding="utf-8", errors="replace").stdout
+        return set(files.splitlines())
+    out = set()                                       # untracked guide: walk its own directory
+    for base, _, names in os.walk(d):
+        rel = os.path.relpath(base, d)
+        for n in names:
+            out.add(n if rel == "." else os.path.join(rel, n))
+    return out
+
+
+def repo_resolves(token, repo_files):
+    """A repo-internal reference resolves if the prompts repo has a matching
+    file (exact, or a unique-enough basename/suffix), or a directory for a
+    trailing-slash reference."""
+    s = token.lstrip("./")
+    while s.startswith("../"):
+        s = s[3:]
+    if s.startswith("review-prompts/"):
+        s = s[len("review-prompts/"):]
+    if s.endswith("/"):
+        pre = s.rstrip("/") + "/"
+        return any(("/" + f).endswith("/" + pre[:-1] + "/") or f.startswith(pre)
+                   for f in repo_files)
+    return any(f == s or f.endswith("/" + s) for f in repo_files)
+
+
 def run(tree, guides, opts):
     """Check every guide; return (findings, stats). Symbol lookups for all
     guides are batched into one probe pass."""
     per_guide = []
     footer_findings = []
     spec_index = load_spec_index(opts.spec_index)
+    repo_files = repo_file_set(guides[0]) if guides else frozenset()
     for path in guides:
         guide = os.path.basename(path)
         with open(path, encoding="utf-8") as f:
@@ -656,7 +777,7 @@ def run(tree, guides, opts):
     findings = list(footer_findings)
     stats = Counter()
     for path, lines, cites in per_guide:
-        gf, gs = check_guide(tree, path, lines, cites, sym_hit, opts)
+        gf, gs = check_guide(tree, path, lines, cites, sym_hit, opts, repo_files)
         findings += gf
         stats += gs
         if spec_index is not None:
@@ -722,6 +843,11 @@ def selftest():
                     "struct memslot_map { int member; };\n")
         with open(os.path.join(repo, "mm", "other.c"), "w") as f:
             f.write("void unrelated(void) {}\n")
+        os.makedirs(os.path.join(repo, "net"))
+        with open(os.path.join(repo, "mm", "shared.c"), "w") as f:
+            f.write("void mm_fn(void) {}\n")
+        with open(os.path.join(repo, "net", "shared.c"), "w") as f:
+            f.write("void net_fn(void) {}\n")
         with open(os.path.join(repo, "Documentation", "note.rst"), "w") as f:
             f.write("The doc_only_symbol lives only here.\n")
         env = dict(os.environ, GIT_AUTHOR_NAME="t", GIT_AUTHOR_EMAIL="t@t",
@@ -766,12 +892,63 @@ def selftest():
 
         # C2: a live symbol resolves, a vanished one is a finding, a symbol that
         # survives only under Documentation/ is a finding (corpus excludes it).
-        got = findings_for("`live_helper` is fine, `vanished_helper` is gone, "
-                           "`doc_only_symbol` only in docs.\n")
+        got = findings_for("`live_helper` is fine, `vanished_helper` is called here, "
+                           "`doc_only_symbol` appears in docs.\n")
         want("C2 gone", got,
              [("C2", "error", "undefined symbol 'vanished_helper'"),
               ("C2", "error", "undefined symbol 'doc_only_symbol'")],
              [("C2", "error", "undefined symbol 'live_helper'")])
+
+        # Parser generalizations (F4): each FP class the repo-wide sweep exposed.
+        with open(os.path.join(d, "sibling.md"), "w") as fh:
+            fh.write("x\n")
+        # Repo-internal references resolve against the prompts repo, not the kernel.
+        got = findings_for("See `sibling.md`, but `nope.md` is missing.\n")
+        want("repo-internal resolves vs missing", got,
+             [("C1", "error", "unresolved guide reference 'nope.md'")],
+             [("C1", "error", "unresolved guide reference 'sibling.md'")])
+
+        # Absolute runtime paths, glob and metavariable paths are not citations.
+        # The glob need not follow a directory (`*_util.h`), and a metavariable
+        # can stand in for a path component (`tools/testing/selftests/<sub>/`).
+        got = findings_for("Read `/proc/meminfo`; touch `include/linux/bpf*.h` "
+                           "and `wrap_begin/end`; see `*_util.h` under "
+                           "`tools/testing/selftests/<sub>/`.\n")
+        want("abs, glob and metavariable paths skipped", got, [],
+             [("C1", "error", "undefined path '/proc/meminfo'"),
+              ("C1", "error", "undefined path 'include/linux/bpf*.h'"),
+              ("C1", "error", "undefined path '*_util.h'"),
+              ("C1", "error", "undefined path 'tools/testing/selftests/<sub>/'")])
+
+        # A bare basename matching several real files still exists; not a finding.
+        got = findings_for("The helper lives in `shared.c` in the tree.\n")
+        want("ambiguous basename skipped", got, [],
+             [("C1", "error", "ambiguous path fragment 'shared.c' (2 matches)")])
+
+        # A 0-hit fragment / metavariable / metasyntactic placeholder is not drift.
+        got = findings_for("`8250_dwlib.o`, `_scoped` variants, `QCM_` prefix, "
+                           "`__raw_readN` family, `pXd_mkspecial`, `foo_pm_ops`, "
+                           "`alloc_thing`, `my_free`.\n")
+        want("fragment/metavar/metasyntactic skipped", got, [],
+             [("C2", "error", "undefined symbol '_dwlib'"),
+              ("C2", "error", "undefined symbol '_scoped'"),
+              ("C2", "error", "undefined symbol 'QCM_'"),
+              ("C2", "error", "undefined symbol '__raw_readN'"),
+              ("C2", "error", "undefined symbol 'pXd_mkspecial'"),
+              ("C2", "error", "undefined symbol 'foo_pm_ops'"),
+              ("C2", "error", "undefined symbol 'alloc_thing'"),
+              ("C2", "error", "undefined symbol 'my_free'")])
+
+        # A live symbol keeps its underscore/metavariable shape (suppression is
+        # only for 0-hit tokens, never a real symbol).
+        got = findings_for("`live_helper` is fine even as `_live_helper` shape.\n")
+        want("suppression never hides a live symbol", got, [],
+             [("C2", "error", "undefined symbol 'live_helper'")])
+
+        # A citation the guide documents as removed is not flagged as drift.
+        got = findings_for("`vanished_helper` has been removed from the tree.\n")
+        want("removal-notice suppressed", got, [],
+             [("C2", "error", "undefined symbol 'vanished_helper'")])
 
         # A live symbol cited beside an unrelated file is not a finding:
         # existence is tree-wide, and a same-paragraph path is a coincidence,

--- a/kernel/subsystem/arm64.md
+++ b/kernel/subsystem/arm64.md
@@ -412,7 +412,7 @@ you MUST follow the BBM sequence to prevent TLB conflicts.
   issuing CPU (for executable mappings or where local synchronization is
   required).
 - Missing `isb()` after TLBI in mode-entry paths (e.g., `enter_vhe()`, nVHE
-  `__tlb_switch_to_guest()`, `__primary_switch()`); the TLBI is not
+  `enter_vmid_context()`, `__primary_switch()`); the TLBI is not
   synchronized to the new execution context without it.
 - Updating a live page table entry (changing OA to a non-matching address or
   attributes) without an intervening invalidation (skipping the "Break" step).
@@ -527,3 +527,5 @@ register state or performing incorrect state merges.
   mid-batch. In interrupt contexts the batching window is broken and an
   explicit barrier must be issued before the interrupted path observes the
   mappings.
+
+<!-- drift-checked: rev=bd5f485f3f026225b86573e559af0b7254ef4184 date=2026-08-21 -->

--- a/kernel/subsystem/cxl.md
+++ b/kernel/subsystem/cxl.md
@@ -10,7 +10,7 @@ backing resource against HMAT memory targets. `resource_contains()` in
 between the two resources. A resource created without `IORESOURCE_MEM`
 has type `0`, while the HMAT target resource has type `IORESOURCE_MEM`, so
 every comparison fails. The function then returns `0` (success) with
-`*cache_size = 0`, and `cxl_acpi_set_cache_size()` in `drivers/cxl/acpi.c`
+`*cache_size = 0`, and `cxl_setup_extended_linear_cache()` in `drivers/cxl/acpi.c`
 stores that zero. The visible effect is that CXL regions with extended
 linear cache report half their actual size, and MCE memory-error reporting
 uses incorrect offsets.

--- a/kernel/subsystem/hyp-arm64.md
+++ b/kernel/subsystem/hyp-arm64.md
@@ -740,3 +740,5 @@ as a regression** — neither form is more or less correct than the other, and
     - **REPORT as bugs:** Code that disables an asynchronous feature but fails
       to execute a subsequent synchronization barrier before changing the
       translation context (e.g., updating `VTTBR_EL2` or `TTBRn_ELx`).
+
+<!-- drift-checked: rev=bd5f485f3f026225b86573e559af0b7254ef4184 date=2026-08-21 -->

--- a/kernel/subsystem/kvm-arm64.md
+++ b/kernel/subsystem/kvm-arm64.md
@@ -144,9 +144,16 @@ access patterns.
 *   **Feature ID / RESx Writeable Mask:** `ID_AA64*` register fields exposed
     to userspace must have correct writeable masks and runtime sanitization. A
     field that is RES0 in the hardware but exposed as writable causes silent
-    guest misconfiguration. Every new field exposure must be paired with the
-    correct `kvm_id_reg_rw_mask` or RESx-handling entry and a corresponding
-    trap/enablement in `HCR_EL2`, `CPTR_EL2`, or `MDCR_EL2`.
+    guest misconfiguration. A field is user-writable only through the register's
+    writable-field mask, and a userspace write is accepted only if it is a safe
+    subset of KVM's sanitised limit, so a guest can never be advertised a feature
+    the host does not support. In the current tree that mask is the ID register
+    descriptor's writable-bits value (`ID_WRITABLE` / `ID_FILTERED` entries;
+    `ID_SANITISED` makes a register read-only) and the subset check is
+    `arm64_check_features()`; confirm the entry and the check against the tree
+    under review rather than a remembered symbol name. Every new field exposure
+    must be paired with the correct writable-mask or RESx-handling entry and a
+    corresponding trap/enablement in `HCR_EL2`, `CPTR_EL2`, or `MDCR_EL2`.
 *   **`vcpu_sysreg` numbering is sparse — never range-check it:** `enum
     vcpu_sysreg` (`arch/arm64/include/asm/kvm_host.h`) indexes
     `vcpu->arch.ctxt.sys_regs[]`, but VNCR-mapped entries are numbered by their
@@ -231,3 +238,5 @@ of resource leaks and stale-state bugs.
   the change.
 - Guest-entry paths that load LRs or VMCR before re-synchronizing
   `ICH_HCR_EL2` trap bits.
+
+<!-- drift-checked: rev=bd5f485f3f026225b86573e559af0b7254ef4184 date=2026-08-21 -->

--- a/kernel/subsystem/kvm.md
+++ b/kernel/subsystem/kvm.md
@@ -14,7 +14,7 @@ and are easy to miss in a focused review:
   behaviour the guest can observe (a new ioctl, a new VM or vCPU capability, a
   new exit reason, a new emulated instruction) MUST be off by default and
   discoverable through the architecture's standard enumeration interface, for
-  example `KVM_CHECK_EXTENSION` / `KVM_CAP_*`, `KVM_GET_SUPPORTED_CPUID2` on
+  example `KVM_CHECK_EXTENSION` / `KVM_CAP_*`, `KVM_GET_SUPPORTED_CPUID` on
   x86, or ID-register feature bits on ARM64. Silently-on features break live
   migration and make capability negotiation impossible.
 - **No guest- or host-userspace-reachable `WARN_ON` / `BUG_ON`.** A `WARN_ON`
@@ -102,12 +102,14 @@ translation usage.
 ```c
 // WRONG: Accessing memslots without SRCU protection
 struct kvm_memslots *slots = kvm_memslots(vcpu->kvm);
-hva = __gfn_to_hva_memslots(slots, gfn); // Potential UAF
+struct kvm_memory_slot *slot = __gfn_to_memslot(slots, gfn);
+hva = __gfn_to_hva_memslot(slot, gfn); // Potential UAF
 
 // CORRECT: Protecting with SRCU
 int idx = srcu_read_lock(&kvm->srcu);
 struct kvm_memslots *slots = kvm_vcpu_memslots(vcpu);
-hva = __gfn_to_hva_memslots(slots, gfn);
+struct kvm_memory_slot *slot = __gfn_to_memslot(slots, gfn);
+hva = __gfn_to_hva_memslot(slot, gfn);
 srcu_read_unlock(&kvm->srcu, idx);
 ```
 
@@ -227,3 +229,5 @@ information or NULL pointer dereferences.
   sequence after pinning.
 - `KVM_SET_USER_MEMORY_REGION2` handlers that permit GPA overlap between
   private and public memslots.
+
+<!-- drift-checked: rev=bd5f485f3f026225b86573e559af0b7254ef4184 date=2026-08-21 -->

--- a/kernel/subsystem/nfsd.md
+++ b/kernel/subsystem/nfsd.md
@@ -84,7 +84,7 @@ completes. Use temp variables until validation passes. Pattern from
 `nfsd_set_fh_dentry()` fix (b3da9b141578).
 
 **Refcount pairs:**
-- `nfs4_get_stid` / `nfs4_put_stid`
+- `refcount_inc(&stid->sc_count)` / `nfs4_put_stid` (the acquire is open-coded; there is no `nfs4_get_stid` helper)
 - `nfsd_file_get` / `nfsd_file_put`
 - `exp_get` / `exp_put`
 - `fh_put` (copy semantics)
@@ -116,12 +116,12 @@ drains stateids (each `nfs4_free_ol_stateid` drops its owner ref via
 succeeds. Access before verification causes NULL dereference or stale data use.
 
 **Permission flags:** `NFSD_MAY_*` flags must match the operation:
-- `MAY_READ` before read operations
-- `MAY_WRITE` before write operations
-- `MAY_EXEC` for directory traversal
-- `MAY_SATTR` for setattr
+- `NFSD_MAY_READ` before read operations
+- `NFSD_MAY_WRITE` before write operations
+- `NFSD_MAY_EXEC` for directory traversal
+- `NFSD_MAY_SATTR` for setattr
 
-Common bug: using `MAY_READ` before `vfs_write()` (wrong flag for operation).
+Common bug: using `NFSD_MAY_READ` before `vfs_write()` (wrong flag for operation).
 
 **File type enforcement:** Pass `S_IFREG`/`S_IFDIR` to `fh_verify()` when the
 caller assumes a specific file type. Using `0` skips the check.

--- a/kernel/subsystem/perf.md
+++ b/kernel/subsystem/perf.md
@@ -3,7 +3,7 @@
 ## Tool API Callbacks
 
 Omitting event callbacks in `struct perf_tool` causes incoming events to be
-silently dropped. In pipe mode, dropping `perf_event_header_attr` events
+silently dropped. In pipe mode, dropping `perf_record_header_attr` events
 prevents the creation of evlists/evsels, breaking event processing entirely.
 
 - Unregistered event types are silently ignored

--- a/kernel/subsystem/pmdomain.md
+++ b/kernel/subsystem/pmdomain.md
@@ -49,8 +49,9 @@ malfunction.
 
 `genpd_power_off_unused()` runs at `late_initcall_sync`
 (`drivers/pmdomain/core.c`). It iterates all registered genpds and queues
-`genpd_power_off_work` for each, which asynchronously attempts to power off
-domains with no active consumers. Domains with `stay_on == true` are skipped.
+each genpd's `power_off_work`, whose handler `genpd_power_off_work_fn()`
+asynchronously attempts to power off domains with no active consumers. Domains
+with `stay_on == true` are skipped.
 
 `regulator_init_complete()` also runs at `late_initcall_sync`
 (`drivers/regulator/core.c`), but it does not disable regulators


### PR DESCRIPTION
## Summary

This adds `check-drift.py`, which verifies the mechanically checkable citations
in a subsystem guide against a kernel tree, and fixes the drift it found.
Calibrated on the four arm64/KVM guides and then run over all 62 in the
repository, it found real drift in eighteen of them: three of the four arm64/KVM
guides, four more this change also fixes, and eleven left to their authors (see
Repo-wide below).

The four arm64/KVM subsystem guides cite kernel paths, symbols, and commits. A
citation can be wrong from the start, or go stale later as the kernel moves: a
function is renamed, a file moves, a symbol is removed. Checking the four guides
against mainline turned up five stale citations across four distinct defects
(one defect appears on two lines), in three of the four guides; hyp-arm64.md was
already clean and gains only a footer. All four defects were wrong when their
lines were written, not valid once and broken later, and review caught none of
them.

## The drift

Three of the four name a symbol with no kernel history at all:

- `__gfn_to_hva_memslots` (kvm.md) pluralizes a helper that only ever existed in
  the singular, `__gfn_to_hva_memslot`. The fix takes a single slot, derived via
  `__gfn_to_memslot()`, so the worked example type-checks against the real API.
- `KVM_GET_SUPPORTED_CPUID2` (kvm.md) names the struct `kvm_cpuid2` as if it were
  the ioctl. The ioctl is `KVM_GET_SUPPORTED_CPUID`.
- `kvm_id_reg_rw_mask` (kvm-arm64.md) has no commit in arch/arm64 history at all.
  The prose is rewritten to state the invariant (a writable-field mask, and
  `arm64_check_features()` accepting a userspace write only for a safe subset of
  the sanitised limit) instead of naming a specific symbol.

The fourth had a real referent. `__tlb_switch_to_guest` (arm64.md) was an nVHE
helper, renamed to `enter_vmid_context` in v6.10 (May 2024). The guide line was
written in April 2026, so it inherited a symbol that had been dead for nearly
two years.

Checking the pre-fix guides against a range of releases separates two effects.
Five findings hold at every release across the window. The count climbs to twelve
at older releases, where the guides also cite symbols and commits that had not
landed yet: valid at HEAD, but not against a tree that predates them.

| Release | Pre-fix findings |
|---|---|
| v6.16 (2025-07) | 12 |
| v6.18 (2025-11) | 12 |
| v6.19 (2026-02) | 11 |
| v7.0 (2026-04) | 7 |
| v7.1 (2026-06) | 5 |
| HEAD (v7.2-2576, 2026-08) | 5 |

Validity is relative to a specific revision. The checker measures it against a
named tree instead of leaving it assumed.

## Repo-wide

The rot is not an arm64 quirk. Run over all 62 guides in the repository, not only
the four this change onboards, the checker found 215 raw findings; generalizing
the false-positive filters (see The checker below, and the suppression classes
listed in `kernel/docs/drift-checker.md`) and fixing the mechanical drift brings
that to 93. Those that remain are real drift in eleven subsystems the
checker was never tuned for (39 stale citations) plus false positives it still
cannot classify.

Two of those false-positive classes are worth naming, because the guides merged
since this was first posted show both. A path citation carrying a glob with no
directory component (`*_util.h`) or a metavariable component
(`tools/testing/selftests/<subsys>/`) was reported as a broken path; that is
fixed here, with a self-test case. The one that is not fixed is worked-example
identifiers: the checker decides that an identifier inside a fenced example is
example-local from a list calibrated on the arm64/KVM guides, so invented names
in other guides (`frobnicate`, `custom_report_callback`, `read_reg_ordinary`)
are reported as undefined symbols. That accounts for 27 of the
findings above, across nine guides, none of them onboarded. The obvious rule,
suppressing an identifier that never appears outside a fenced block, is wrong:
`__gfn_to_hva_memslots` in `kvm.md` is real drift this change fixes and appears
only inside an example. Deciding example-locality structurally is the fix, and
it wants its own change rather than this one.

This change fixes four more subsystems, one commit each: `cxl`
(`cxl_acpi_set_cache_size` -> `cxl_setup_extended_linear_cache`), `nfsd` (an
open-coded stateid refcount, and `MAY_*` -> `NFSD_MAY_*`), `perf`
(`perf_event_header_attr` -> `perf_record_header_attr`), and `pmdomain` (a work
item and its handler). These guides gain no footer: fixing a guide's drift and
onboarding it are separate steps, and onboarding stays with each guide's author.

The rest is real drift whose fix is a mechanism rewrite, not a name swap, because
the kernel restructured what the rule describes: the devmap page-table bits were
removed wholesale (mm-pagetable), the mTHP swap-cache scheme was rearchitected
(mm-largepage, mm-reclaim), the ksmbd smbdirect stack moved into a shared library
(smb-ksmbd), the btf map-value field cleanup was split into a cancel path and a
free path, and so on across block, io_uring, mm-alloc, mm-folio, mm-vma, and vfs.
Each is left for the subsystem's own maintainer rather than rewritten from
outside. Running the checker with `--all` over one of those guides reports its
stale citations, which is the starting point for whoever owns it.

Because a guide is checked only when it carries a footer, none of this reaches a
default run: no maintainer inherits a check they did not accept.

## The checker

`kernel/scripts/check-drift.py` verifies the mechanically checkable citations in
a guide against a local kernel tree and reports each stale one, compiler-style,
`<guide>:<line>: <check>: <message>`. It is stdlib-only Python 3 and reaches the
tree through git plumbing (`git cat-file`, `git grep`, `git log`) only, so it
runs wherever git and Python 3 are, adds no build dependencies, and never
modifies the tree. Every query takes a revision, so a guide can be checked
against any release.

It checks paths (C1), symbols in prose and in fenced examples (C2), commit SHAs
and subjects (C3), and a per-guide verification footer (C4). It deliberately
does not check what it cannot check without false positives: register, field,
and instruction names, which are Arm Architecture Reference Manual facts a tree
lookup cannot confirm; placeholders and pseudo-code; and tokens too generic for
an existence check to mean anything. 334 of 1130 citations (30%) are checked; the
rest are left to prose review, and `--stats` prints that breakdown per class so
the figure can be reproduced rather than taken on trust. A noisy
checker is worse than none, so the cut favours precision, and the measured
fraction is stated in the conventions doc (`kernel/docs/drift-checker.md`).

Two design points keep this from adding maintenance burden:

- **Opt-in per guide.** A guide is checked only if it carries a footer as its
  last line; a guide without one is skipped with an informational line and is
  never reported as drift. So a default run over `kernel/subsystem/*.md` checks
  the onboarded guides and passes over the rest. This PR onboards four (the
  arm64/KVM guides); the four other subsystem guides it fixes gain no footer, so
  nothing starts checking them. Adoption is per guide, per author.
- **No new in-guide markup beyond that footer.** The guides are fed to their
  readers verbatim, so an inline ignore comment would travel into every review's
  context. False-positive suppression lives in the checker instead, and the
  footer itself is an HTML comment that does not render.

Mechanical checking and drift-robust prose are complementary. Commit `87f4136`
in this repo rewrote the `SCTLR_EL2_RES1` example so it does not pin to one
revision's init-macro contents, which removes that citation from the checkable
surface entirely. Robust prose reduces how many citations there are; the checker
verifies the ones that remain.

## Running it

The checker runs locally against a full kernel tree, which is the primary path
and exercises every check. A run over the guide directory checks whatever carries
a footer and skips the rest, so it needs no per-guide argument:

```
python3 kernel/scripts/check-drift.py --tree /path/to/linux kernel/subsystem/*.md
```

Today that checks the four onboarded arm64/KVM guides and reports the other 58 as
not onboarded, one informational line each, exiting 0.

`--require-footer` turns a missing footer into an error for the guides named on
the command line, which is what CI uses on the onboarded set. To survey a guide
that has not been onboarded, and so decide whether it is ready to carry a footer,
`--all` checks its citations without one:

```
python3 kernel/scripts/check-drift.py --tree /path/to/linux --all \
    kernel/subsystem/<your-guide>.md
```

`--rev` points any of these at a release rather than HEAD.

The last commit adds an optional GitHub Actions workflow that runs the check on a
pull request touching a guide, and weekly. It is the tip of the series and can be
dropped with `git revert` without affecting the checker or the fixes. CI uses a
depth-1 kernel clone, which has no commit history, so under a shallow tree the
checker skips the history-dependent checks (commit citations and the footer's
ancestor check) and verifies paths and symbols, rather than reporting a citation
as broken for want of history.

## Contents

The series builds the checker, then applies it, then adds the optional CI:

- Conventions doc and the checker, then two commits extending it: scoping the
  commit checks to the revision under review, and generalizing the
  false-positive filters (with a self-test case per class).
- One commit per guide for the four arm64/KVM guides, each re-verified against
  the tree and each gaining a verification footer. Three carry citation fixes;
  hyp-arm64.md was already clean, so its commit adds the footer only.
- One commit per guide for four more subsystem fixes (cxl, nfsd, perf,
  pmdomain), each re-verified against the tree; no footer, since onboarding is
  the author's step.
- The optional CI workflow, last and separable.
