### PR TITLE
Assisted-by: is a legitimate tag

### DIFF
--- a/kernel/inline-template.md
+++ b/kernel/inline-template.md
@@ -14,6 +14,13 @@ any summary, comments or questions you add should be wrapped at 78 characters
   Claude, AI review output, GitHub Actions CI run summaries, or any other bot
   as evidence for an issue.
 
+  Note: ``Assisted-by:`` tags in commit messages are NOT bot review evidence.
+  They are documented kernel metadata per
+  Documentation/process/coding-assistants.rst and should never be flagged as
+  issues. The ban above applies to citing AI/bot tools as *independent
+  corroboration* for a finding (\"Claude also found this bug\"), not to the
+  ``Assisted-by:`` trailer itself.
+
 - If an issue depends on, overlaps, or repeats automated review feedback, omit
   the entire issue. Do not rewrite "Sashiko found this" into neutral wording.
   Only report issues supported independently by source code, commit messages,

--- a/kernel/subsystem/boot-params.md
+++ b/kernel/subsystem/boot-params.md
@@ -1,0 +1,45 @@
+# Boot Parameter Subsystem Guide
+
+## Documentation Requirement
+
+Every boot parameter added or changed (via `__setup()`, `early_param()`,
+`module_param()`, or any command-line option parsed at boot) must be
+documented in `Documentation/admin-guide/kernel-parameters.txt`.
+
+**REPORT as regressions**: Any patch that adds or changes a kernel
+command-line parameter without a corresponding update to
+`Documentation/admin-guide/kernel-parameters.txt`.
+
+### Triggers
+
+The following signals indicate a boot parameter is being modified:
+
+- `__setup("` — kernel command-line parameter handler
+- `early_param("` — early boot parameter handler
+- `module_param(` — module parameter (module parameters accessible at boot
+  via `<module>.<param>=` also go in kernel-parameters.txt)
+- `module_param_named(` — same
+- `core_param(` — core kernel parameter
+- Boot parameter strings in commit messages: `kernel command-line`,
+  `boot parameter`, `cmdline`, `command-line option`
+
+### Exceptions
+
+- Debug-only parameters gated by `#ifdef CONFIG_DEBUG_KERNEL` may be
+  documented in the parameter file or in a comment near the definition.
+  Flag but do not require a kernel-parameters.txt entry for these.
+- Parameters defined and consumed entirely within a single driver's
+  `CONFIG_EXPERIMENTAL`-gated code path that has no user-facing
+  documentation expectation. Still flag for reviewer awareness.
+
+### Checklist
+
+When a patch matches any trigger:
+
+1. Check if `Documentation/admin-guide/kernel-parameters.txt` is also
+   modified in the diff.
+2. If not modified, the parameter is missing documentation — report as
+   a regression unless an exception applies.
+3. If modified, verify the documentation entry includes: parameter name,
+   format (`tlbi=off` or `tlbi=[off]`), what it controls, and the
+   architectures it applies to.

--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -48,6 +48,7 @@ and symbols regexes.
 | btrfs | fs/btrfs/ | btrfs.md |
 | DAX | dax operations | dax.md |
 | Block/NVMe | block layer, nvme | block.md |
+| Boot Parameters | `__setup("`, `early_param("`, `module_param(`, `module_param_named(`, `core_param(`, `boot parameter`, `cmdline`, `command-line` | boot-params.md |
 | DRM/GPU | drivers/gpu/drm/, drm_atomic_, drm_crtc_, hwseq, hw_sequencer | drm.md |
 | NFSD | fs/nfsd/*, fs/lockd/* | nfsd.md |
 | SunRPC | net/sunrpc/* | sunrpc.md |


### PR DESCRIPTION
Running /kreview with a Deepseek instance that had not done kernel development resulted in a complaint about a "non-standard" Assisted-by: header.

Add some text to avoid that in the future.

Assisted-by: Hermes:deepseek-v4-pro