### PR TITLE
gic: add GICv3/v4 and GICv5 subsystem review guides

### DIFF
--- a/kernel/subsystem/gic-v3.md
+++ b/kernel/subsystem/gic-v3.md
@@ -1,0 +1,1225 @@
+# GICv3/v4 Subsystem Details
+
+This guide covers invariants and bug patterns for GICv3 and GICv4/v4.1: the
+host irqchip driver (`drivers/irqchip/irq-gic-v3.c`,
+`drivers/irqchip/irq-gic-v3-its.c`, `drivers/irqchip/irq-gic-v4.c`), the shared
+register definitions (`include/linux/irqchip/arm-gic-v3.h`,
+`include/linux/irqchip/arm-gic-v4.h`), and KVM's virtual GIC
+(`arch/arm64/kvm/vgic/`, `include/kvm/arm_vgic.h`). It is derived from the
+merged upstream implementation, its fix history, and the Arm Generic Interrupt
+Controller Architecture Specification, GICv3 and GICv4 (ARM IHI 0069).
+
+GICv2 is out of scope. GICv5 is a redesign rather than an extension and has its
+own guide, `gic-v5.md`; the only place the two meet is a GICv3 guest running in
+compatibility mode on GICv5 hardware, covered in "GICv5 Hardware Running a
+GICv3 Guest" below.
+
+Three sibling guides own rules that are deliberately **not** repeated here, and
+a reviewer should load them alongside this one rather than expect this file to
+be self-contained:
+
+- `kvm-arm64.md` owns the VGIC CPU interface access rules (`ICV_AP<n>R_EL1`
+  write ordering, `ICV_IAR*` self-synchronization, `ICC_SRE_EL1_NS.SRE` gating
+  of the memory-mapped `GICV_*` frame), the `ICH_HCR_EL2` trap-ordering rules,
+  the vGIC lock-ordering rules over `irq_lock` and the LPI xarray, and the
+  first-run resource ordering.
+- `arm64.md` owns the sysreg synchronization rules, including which register
+  writes each RWP bit tracks and the `ICC_PMR_EL1` self-synchronization and
+  `pmr_sync()` rules.
+- `technical-patterns.md` owns generic kernel patterns (double-fetch,
+  read-modify-write without write-back, allocation-context rules) that turn up
+  in this code but are not specific to it.
+
+Where this guide touches an area a sibling covers, it goes deeper into the GIC
+mechanism rather than restating the sibling's rule, and says so.
+
+## The ITS Command Queue Is a Ring Plus a Doorbell
+
+The ITS is programmed by writing command entries into a ring in Normal memory
+and then writing a doorbell register. Every one of the four steps — build,
+publish, ring, wait — can be got wrong on its own, and three of the four fail
+silently.
+
+> A command the ITS never observes is simply not executed: the device mapping
+> is absent, so every MSI from that device is dropped, with no error anywhere.
+> A command whose completion is not waited for lets the next operation proceed
+> against state the ITS has not yet reached. A queue that is rung with a
+> malformed entry can stall, and a stalled queue stops processing everything
+> behind it.
+
+The canonical sequence is the `BUILD_SINGLE_CMD_FUNC` macro in
+`drivers/irqchip/irq-gic-v3-its.c`, which expands into `its_send_single_command()`
+and `its_send_single_vcommand()`. Read it as the reference shape:
+`its_allocate_entry()`, the command builder, `its_flush_cmd()`, optionally a
+second entry for the SYNC, then `its_post_commands()` and
+`its_wait_for_range_completion()`.
+
+*   **The publish step is conditional on coherency; the barrier is not.**
+    `its_flush_cmd()` selects `gic_flush_dcache_to_poc()` when the ITS is
+    flagged `ITS_FLAGS_CMDQ_NEEDS_FLUSHING` and `dsb(ishst)` otherwise, under
+    the comment "Make sure the commands written to memory are observable by the
+    ITS". A new path that writes command entries must go through the same
+    helper rather than hardcoding either arm, and neither arm may be omitted:
+    the store into the queue is a Normal-memory store and the doorbell is a
+    Device store, so nothing orders them by default.
+
+*   **That ordering requirement comes from the base architecture, not from the
+    GIC specification.** IHI 0069 contains no sentence requiring a barrier or
+    cache maintenance on the queue before `GITS_CWRITER` is written; the GIC
+    specification defers explicitly, saying "For more information on
+    endianness, memory ordering, and barrier instructions, see Arm®
+    Architecture Reference Manual for A-profile architecture". Do not ask a
+    patch to cite a GIC-specification rule for this, and do not treat the
+    absence of such a citation as evidence the barrier is unnecessary.
+
+*   **The analogous requirement that *is* in the GIC specification concerns the
+    ITS tables, not the queue.** For a two-level table, "A write to a level 1
+    table entry that changes the valid bit from 0 to 1 must be globally visible
+    before software adds a command to the ITS command queue that relies on that
+    entry. Otherwise it is UNKNOWN if the command will succeed or if it will be
+    ignored." A patch that publishes a new level 2 table and immediately queues
+    a command referencing it needs that visibility, and this one you can cite.
+
+*   **`GITS_CREADR` is sampled before the doorbell, under the queue lock.** The
+    completion wait needs the read pointer as it was *before* the new commands
+    were made visible, because it computes progress as a delta. Sampling it
+    after ringing conflates "the ITS has already consumed these" with "no
+    progress yet". The completion wait itself runs after the lock is dropped.
+
+    ```c
+    /* CORRECT: sample, ring, unlock, then wait on the sampled origin */
+    rd_idx = readl_relaxed(its->base + GITS_CREADR);
+    next_cmd = its_post_commands(its);
+    raw_spin_unlock_irqrestore(&its->lock, flags);
+    its_wait_for_range_completion(its, rd_idx, next_cmd);
+
+    /* WRONG: the origin is read after the ITS may already have advanced */
+    next_cmd = its_post_commands(its);
+    rd_idx = readl_relaxed(its->base + GITS_CREADR);
+    ```
+
+*   **Ring-index arithmetic must linearize the wrap before comparing.**
+    `its_wait_for_range_completion()` adds `ITS_CMD_QUEUE_SZ` to the target
+    offset when it is below the origin, and again to the per-iteration delta
+    when the read pointer has wrapped. A comparison of raw offsets is wrong for
+    exactly the commands that straddle the wrap, which is why this class of bug
+    survives light testing.
+
+*   **Every command builder must end in `its_fixup_cmd()`.** That helper
+    converts the whole four-doubleword command to little-endian
+    (`raw_cmd_le[n] = cpu_to_le64(raw_cmd[n])`). A builder that returns without
+    calling it leaves host-endian data in the queue, which is correct on a
+    little-endian build and silently wrong on a big-endian one. Check every
+    return path, including early `goto`s: `its_build_vmapp_cmd()` reaches its
+    `its_fixup_cmd()` through a shared `out:` label precisely so that its two
+    early exits cannot skip it.
+
+*   **A command error has three architecturally permitted outcomes and software
+    may assume none of them.** The specification states that "If the ITS
+    detects an error in the data provided to a command, the resulting behavior
+    is a CONSTRAINED UNPREDICTABLE choice of: • Ignoring the command ... •
+    Stalling the ITS command queue ... • Treating the data as valid data". Code
+    or a commit message that reasons "the ITS will just ignore the bad command"
+    is relying on one arm of a CONSTRAINED UNPREDICTABLE choice.
+
+*   **A stalled queue has an architected restart path, and anything that can
+    stall must preserve it.** When the ITS stalls, `GITS_CREADR` stops
+    advancing and `GITS_CREADR.Stalled` reads 1; "When GITS_CREADR.Stalled == 1
+    no subsequent commands are processed". Software restarts it by writing 1 to
+    `GITS_CWRITER.Retry`, which "Restarts the processing of commands by the ITS
+    if it stalled because of a command error". An emulation of the ITS that can
+    enter the stalled state without implementing `Retry` has turned a
+    recoverable command error into an unrecoverable wedge of every subsequent
+    command.
+
+*   **A `GITS_CWRITER` value outside the range implied by `GITS_CBASER` is a
+    separate failure mode.** Behavior is a CONSTRAINED UNPREDICTABLE choice
+    between treating the command queue as invalid until a valid value is
+    written, and treating the value as valid and UNKNOWN. Validate the offset
+    before forwarding a value that did not come from the driver's own ring
+    arithmetic.
+
+*   **The queue is considered full one entry short of wrapping onto the read
+    pointer.** `its_queue_full()` tests `((widx + 1) % ITS_CMD_QUEUE_NR_ENTRIES)
+    == ridx`, and `its_allocate_entry()` spins with a bounded count before
+    returning `NULL` rather than overwriting an unconsumed entry. A new
+    allocation path that returns an entry without that check can overwrite a
+    command the ITS has not read.
+
+**REPORT as bugs:**
+*   A write of command entries into the ITS queue with no barrier or cache
+    maintenance before the `GITS_CWRITER` write, or one that hardcodes
+    `dsb(ishst)` or the CMO instead of branching on the ITS's coherency flag.
+*   A command builder with a return path that does not pass through the
+    endianness fixup.
+*   A completion wait whose origin index was sampled after the doorbell write,
+    or ring arithmetic that compares offsets without handling wrap.
+*   Code or a rationale that depends on one particular ITS behaviour after a
+    command error.
+*   An ITS emulation that can stall the queue but does not implement
+    `GITS_CWRITER.Retry` and `GITS_CREADR.Stalled`.
+*   A new level 2 ITS table published and referenced by a queued command
+    without being made globally visible first.
+
+## Completion: SYNC Is Physical, VSYNC Is Virtual
+
+The ITS has two synchronization commands and they are not interchangeable. This
+is the single easiest completion mistake to make in this driver, because the
+wrong one compiles, runs, and appears to work under light load.
+
+> Synchronizing a virtual operation with SYNC synchronizes nothing relevant, so
+> the caller proceeds against state the ITS has not reached: a vLPI
+> configuration change that has not taken effect, or a translation reused while
+> an event for its previous owner is still in flight. In the opposite
+> direction, issuing a VSYNC after a command that has already destroyed its
+> target is a command error for which an SError is architecturally permitted.
+
+*   **SYNC covers physical interrupts; VSYNC covers a vPEID.** SYNC "ensures
+    all outstanding ITS operations associated with physical interrupts for the
+    Redistributor specified by RDbase are globally observed before any further
+    ITS commands are executed". VSYNC "ensures all outstanding ITS operations
+    for the vPEID specified are globally observed before any further ITS
+    commands are executed". The two are wired into different send paths in the
+    driver: `its_send_single_command()` appends a SYNC built by
+    `its_build_sync_cmd()`, and `its_send_single_vcommand()` appends a VSYNC
+    built by `its_build_vsync_cmd()`. A virtual command routed through the
+    physical send path gets the wrong synchronizer *and* addresses the SYNC at
+    a collection whose redistributor need not be the one the vPE is on.
+
+*   **Without one of the two, no ordering exists at all.** "In the absence of a
+    SYNC or VSYNC command the ordering of ITS commands and translation requests
+    is not defined by the architecture." There is no weaker in-between
+    guarantee to rely on.
+
+*   **The builder's return value is control flow, not a diagnostic.** In the
+    send macro, the builder returns the object to synchronize against, and a
+    `NULL` return elides the trailing SYNC or VSYNC entirely. `valid_col()` and
+    `valid_vpe()` return `NULL` when the target is not usable, which
+    incidentally drops the synchronization too. When reviewing a new builder,
+    decide deliberately what it returns on every path; returning `NULL` to mean
+    "nothing to do" silently changes the completion behaviour of the command.
+
+*   **On GICv4.1, unmapping a vPE is self-synchronizing and must not be
+    followed by a VSYNC.** The specification states that "A VMAPP with {V,
+    Alloc}=={0, x} is self-synchronizing. This means the ITS command queue does
+    not show the command as consumed until all of its effects are completed."
+    A VSYNC after it would name a vPE that no longer exists, which is a command
+    error; the architected error code is `VSYNC_VCPU_INVALID`, and where
+    `GITS_TYPER.SEIS` is 1 the implementation may report it as a System error.
+    `its_build_vmapp_cmd()` implements this by setting its returned vPE to
+    `NULL` on the unmap path, with the comment "Unmapping a VPE is
+    self-synchronizing on GICv4.1, no need to issue a VSYNC".
+
+*   **That elision is GICv4.1-only, and the version guard is load-bearing.**
+    The self-synchronization sentence appears in the GICv4.1 VMAPP description;
+    the GICv4.0 VMAPP description contains no such statement. In the driver the
+    `NULL` assignment sits inside an `is_v4_1(its)` test for exactly this
+    reason. A patch that hoists the elision out of the version check removes a
+    required VSYNC on GICv4.0 hardware; a patch that removes the elision
+    reintroduces a VSYNC against an unmapped vPE on GICv4.1.
+
+*   **INVALL is completed by a SYNC.** INVALL "specifies that the ITS must
+    ensure any caching associated with the interrupt collection defined by ICID
+    is consistent with the LPI Configuration tables held in memory for all
+    Redistributors", and the specification is explicit that "A SYNC command
+    completes the INV and INVALL commands". An INVALL issued without its SYNC
+    leaves a window in which the configuration in memory and the configuration
+    the ITS is using disagree.
+
+**Do NOT flag:**
+*   A GICv4.1 VMAPP unmap with no following VSYNC. That is the architected
+    behaviour, not a missing synchronization.
+*   INVDB or VSGI with no explicit VSYNC at the call site. The specification
+    states "INVDB is synchronized by a VSYNC command" and "VSGI is synchronized
+    by VSYNC", and the driver reaches both through the virtual send path, which
+    appends it.
+
+**REPORT as bugs:**
+*   A virtual ITS command (anything naming a vPEID) followed by SYNC rather
+    than VSYNC, or routed through the physical send path.
+*   A VSYNC that can reference a vPE the preceding command unmapped.
+*   A VMAPP unmap on GICv4.0 whose VSYNC has been elided, or a v4.1 elision
+    applied without a version check.
+*   INV or INVALL with no completing SYNC before the caller relies on the new
+    configuration.
+
+## LPI Configuration Is Shared State
+
+LPI configuration is not per-redistributor. A group of redistributors is
+required to use one copy of the LPI Configuration table, and the architecture
+makes divergence within that group UNPREDICTABLE rather than merely
+inconsistent.
+
+> Programming different tables into redistributors that must share one leads to
+> UNPREDICTABLE behaviour, and the partial constraint the architecture layers on
+> top does not rescue it: the GIC picks a copy, and the copy it picks may not be
+> the one whose contents software believes are live. The observable failure is
+> not a crash but silent divergence — interrupts configured on one CPU behaving
+> as if configured differently on another.
+
+*   **`GICR_TYPER.CommonLPIAff` defines the group, by leading affinity
+    fields.** The encoding is: `0b00`, all redistributors are in one group;
+    `0b01`, all with the same Aff3; `0b10`, all with the same Aff3.Aff2;
+    `0b11`, all with the same Aff3.Aff2.Aff1. The requirement attached to it is
+    that "Redistributors in the same CommonLPIAff group must use the same copy
+    of the LPI Configuration table, and if GICv4.1 is implemented the same copy
+    of the vPE Configuration table."
+
+*   **The LPI Pending table is not shared.** The specification says of it:
+    "This table is specific to a particular Redistributor." Extending a sharing
+    argument from the configuration table to the pending table is a category
+    error, and a patch that pins or shares the pending table across a group is
+    doing something the architecture does not ask for.
+
+*   **A CommonLPIAff grouping key clears the low bits and keeps the high
+    ones.** This inverts the usual intuition that "group by a prefix" means
+    "mask down to the low bits", because the packed affinity value places Aff3
+    at the top. `compute_common_aff()` is the worked example: it is
+    `aff & ~(GENMASK(31, 0) >> (clpiaff * 8))`, so `CommonLPIAff == 0b01`
+    retains bits [31:24] (Aff3), `0b10` retains [31:16], `0b11` retains [31:8],
+    and `0b00` retains nothing, putting every redistributor in one group. Any
+    affinity-derived key deserves the same check: write out which Aff field
+    lands in which bits before choosing the mask.
+
+    ```c
+    /* CORRECT: keep the leading affinity fields, discard the trailing ones */
+    return aff & ~(GENMASK(31, 0) >> (clpiaff * 8));
+
+    /* WRONG: keeps the trailing fields, so redistributors required to share a
+     * table are not grouped together, and unrelated ones are */
+    return aff & (GENMASK(31, 0) >> (clpiaff * 8));
+    ```
+
+    Getting this backwards is doubly bad: the redistributors that were supposed
+    to be checked against each other are not, and unrelated ones are grouped
+    spuriously.
+
+*   **Divergent `GICR_PROPBASER` values within a group are UNPREDICTABLE.**
+    "Setting different values in different copies of GICR_PROPBASER on
+    Redistributors that are required to use a common LPI Configuration table
+    when GICR_CTLR.EnableLPIs == 1 leads to UNPREDICTABLE behavior." A
+    secondary sentence constrains it only partially: "If GICR_PROPBASER is
+    programmed to different values on different Redistributors, it is
+    IMPLEMENTATION DEFINED which copy or copies of GICR_PROPBASER are used when
+    the GIC reads the LPI Configuration tables. However, the copy or copies
+    that are used will correspond to a Redistributor on which
+    GICR_CTLR.EnableLPIs == 1." Read that as a floor on how bad it can get, not
+    as a licence: the only guarantee is that the chosen copy belongs to an
+    enabled redistributor.
+
+*   **Table contents have their own publication rule, with three named trigger
+    points.** "To avoid unpredictable behavior, software must ensure that all
+    copies of the LPI Configuration tables are identical, and all changes are
+    globally observable, whenever: • GICR_CTLR.EnableLPIs is written from 0 to
+    1 on any Redistributor. • GICR_INVLPIR and GICR_INVALLR are written on any
+    Redistributor with GICR_CTLR.EnableLPIs == 1, if direct LPIs are supported.
+    • The INV and INVALL command is executed by an ITS, in an implementation
+    that includes at least one ITS." A configuration write followed by neither
+    an invalidate nor an enable transition has not been published at all.
+
+*   **There is no "it will be noticed eventually".** The specification states
+    both that "A cached LPI Configuration table entry is not guaranteed to
+    remain in the cache" and that "A cached LPI Configuration table entry is not
+    guaranteed to remain incoherent with memory". Neither direction can be
+    relied on, which is exactly why the explicit invalidation is the only way to
+    publish a change.
+
+*   **The driver's LPI ID width is a policy cap, not the architectural one.**
+    `lpi_id_bits` is `min_t(u32, GICD_TYPER_ID_BITS(...), ITS_MAX_LPI_NRBITS)`
+    with `ITS_MAX_LPI_NRBITS` set to 16, because the property table is sized as
+    `2^lpi_id_bits` and an implementation advertising 24 bits would demand a
+    16MB contiguous allocation. Where firmware pre-allocated the tables the
+    driver instead reads the width back out of `GICR_PROPBASER.IDBITS` rather
+    than imposing its own. A new consumer of the hardware-advertised width that
+    does not apply the same cap reintroduces the allocation, and a new consumer
+    that assumes the cap on the pre-allocated path contradicts firmware.
+
+**REPORT as bugs:**
+*   An affinity-derived grouping key that masks to the trailing affinity fields
+    instead of the leading ones.
+*   Code that allows, or a change that introduces, different LPI Configuration
+    table bases across a CommonLPIAff group while LPIs are enabled.
+*   An LPI configuration change with no following invalidation, or one that
+    relies on the GIC re-reading memory of its own accord.
+*   A sharing or pinning argument applied to the LPI Pending table.
+*   Consumption of the hardware-advertised LPI ID width on a path where the
+    driver has already narrowed it by policy.
+
+## Redistributor and Distributor Write Completion
+
+Different GIC register writes complete in different ways, and the mechanism is
+not discoverable from the write itself. `arm64.md` carries the list of which
+writes each RWP bit tracks; this section is about the driver-side discipline
+around that list, and about what to do for the writes it does not cover.
+
+> Polling the wrong bit reads as "no write pending" forever, so the poll
+> returns immediately and the caller proceeds against a write that has not
+> landed. For the registers RWP does not track, proceeding without any
+> completion step at all means the write may still be sitting in an
+> interconnect or buffered inside the GIC when the code that depends on it
+> runs.
+
+*   **The two RWP bits live at the same register offset and different bit
+    positions.** `GICR_CTLR` is defined as `GICD_CTLR` — both are at offset
+    0x0000 in their respective frames — but `GICD_CTLR_RWP` is bit 31 while
+    `GICR_CTLR_RWP` is bit 3. Testing the distributor's bit number against a
+    redistributor base therefore compiles, runs, reads a bit that is something
+    else entirely, and reports "no write pending" essentially always. This was
+    a real defect that survived eight years. The driver's defence is
+    structural: `gic_do_wait_for_rwp()` takes the base and the bit as a pair,
+    and the only two callers are `gic_dist_wait_for_rwp()` and
+    `gic_redist_wait_for_rwp()`, each supplying the matched pair.
+
+    ```c
+    /* CORRECT: base and bit chosen together */
+    gic_do_wait_for_rwp(gic_data_rdist_rd_base(), GICR_CTLR_RWP);
+
+    /* WRONG: distributor bit number, redistributor frame — always reads 0 */
+    gic_do_wait_for_rwp(gic_data_rdist_rd_base(), GICD_CTLR_RWP);
+    ```
+
+*   **For the writes RWP does not track, the completion primitive is a
+    read-back.** The set/clear-active and set/clear-pending registers appear in
+    neither RWP list, and there is no other completion bit for them. Two
+    separate mechanisms can delay such a write: the mapping is an early
+    write-acknowledge Device type, so the store may be considered done while it
+    is still in an interconnect, and the GIC itself may buffer the write as
+    long as it takes it into account in finite time. Reading the register back
+    forces the interconnect to propagate the write and the GIC to process it
+    before answering. `gic_irq_set_irqchip_state()` does exactly this, ending
+    with a read-back when it wrote the set-active register, under the comment
+    "Force read-back to guarantee that the active state has taken effect, and
+    won't race with a guest-driven deactivation".
+
+*   **The specification's negative is stronger for the Distributor than for the
+    Redistributor, and a review should not over-claim.** `GICD_CTLR.RWP`'s
+    description ends with an explicit exclusion clause: "Updates to other
+    register fields are not tracked by this field." `GICR_CTLR.RWP`'s
+    description has no equivalent sentence — it gives only the enumeration of
+    what it does track. So on the redistributor side the correct argument is
+    that the enumeration is exhaustive and does not include the active or
+    pending registers, not that the specification states an exclusion. If a
+    patch or a review comment claims a quoted exclusion clause for
+    `GICR_CTLR.RWP`, it is quoting something that is not there.
+
+*   **The Redistributor RWP list has a GICv4.1-only member.** Alongside
+    `GICR_ICENABLER0`, the `GICR_CTLR` DPG fields and the `EnableLPIs` 1-to-0
+    transition, it covers "In FEAT_GICv4p1, GICR_VPROPBASER, which clears Valid
+    from 1 to 0". A GICv4.1 path that clears `GICR_VPROPBASER.Valid` and
+    proceeds without the RWP poll is missing a completion the architecture
+    provides.
+
+*   **RWP tracking on the enable side is clear-only and directional.** The
+    lists name `GICR_ICENABLER0` and `GICD_ICENABLER<n>` — the *clear*-enable
+    registers — and never `GICR_ISENABLER0` or `GICD_ISENABLER<n>`, and the
+    distributor's group enables are tracked "for transitions from 1 to 0 only".
+    Disabling needs the poll; enabling does not.
+
+**Do NOT flag:**
+*   A missing RWP poll after an interrupt *enable*, a group *enable*, or a
+    priority or routing write. None of those is tracked, so there is nothing to
+    poll for.
+*   A read-back after a set-active write, on the grounds that it is a
+    pointless read. It is the completion mechanism.
+
+**REPORT as bugs:**
+*   An RWP poll whose bit constant does not match the frame of the base it is
+    polling.
+*   A set-active or set-pending write whose effect the caller immediately
+    depends on, with no read-back.
+*   A GICv4.1 `GICR_VPROPBASER.Valid` clear with no following RWP poll.
+
+## vPE Residency, Affinity, and Doorbells
+
+GICv4 gives a vPE a residency state in a redistributor and a doorbell for when
+it is not resident. Both the transitions and the locking around them are
+recurring sources of bugs, because the hardware is scanning tables
+asynchronously across the transitions and because changing one vPE's state
+affects interrupts that do not belong to it.
+
+> Writing `GICR_VPENDBASER` while the redistributor is still scanning is
+> UNPREDICTABLE. Losing a doorbell request means a blocked vCPU is never woken
+> for an interrupt that is already pending, which presents as a guest that
+> hangs rather than as a latency problem. Getting the lock order wrong between
+> the per-VM and per-vPE locks deadlocks.
+
+*   **Wait for `GICR_VPENDBASER.Dirty` to clear before descheduling.** The
+    redistributor sets Dirty while it is parsing the virtual pending table
+    after a schedule, and the code path between making a vPE resident and
+    entering the guest is preemptible, so a deschedule can arrive mid-scan. On
+    GICv4.1 the architecture is explicit in both directions: with `Valid == 0`,
+    "Writing 1 to GICR_VPENDBASER.Valid is UNPREDICTABLE while
+    GICR_VPENDBASER.Dirty == 1"; with `Valid == 1`, "Writing 0 to
+    GICR_VPENDBASER.Valid is UNPREDICTABLE while GICR_VPENDBASER.Dirty == 1".
+    Do not quote that pairing at a GICv4.0 implementation: `GICR_VPENDBASER`
+    has two full field-description variants, and in the GICv4.0 one the
+    `Valid == 1` sub-case reads "Writing **1**", additionally gated on
+    `GICR_TYPER.Dirty == 1`. The rule in the next bullet is the
+    variant-independent one and is the safer thing to cite.
+    `its_clear_vpend_valid()` opens by
+    waiting for Dirty to clear, under the comment "Make sure we wait until the
+    RD is done with the initial scan", which makes it a full residency barrier
+    rather than just a Valid-clearing helper.
+
+*   **The whole-register rule is stricter than the Dirty rule alone.** "Writing
+    a new value to any bit of GICR_VPENDBASER, other than
+    GICR_VPENDBASER.Valid, when GICR_VPENDBASER.Valid==1 is UNPREDICTABLE." A
+    patch that adjusts any other field of a live `GICR_VPENDBASER` — even one
+    that looks advisory — is outside the architecture.
+
+*   **Resolve an ambiguous pending answer conservatively.** After the
+    deschedule, if Dirty is still set, `its_clear_vpend_valid()` forces
+    `PendingLast` on rather than reporting "nothing pending". Erring toward a
+    spurious wakeup is correct; erring the other way is a hung vCPU.
+
+*   **`pending_last` is a hint, not a statement about the table.** The
+    schedule path sets `PendingLast` unconditionally and explains why: there is
+    no race-free way to discover that the pending table is empty, because the
+    doorbell can arrive at any moment. Treat `pending_last` as "the vCPU may
+    have something pending". A patch that tightens it into an exact answer is
+    claiming a guarantee the hardware does not offer.
+
+*   **The lock order for any ITSList sequence is documented and three deep.**
+    `include/linux/irqchip/arm-gic-v4.h` states it: `vmapp_lock -> vpe_lock ->
+    vmovp_lock`. The way this gets violated is not by taking locks in the wrong
+    order at one site, but by a function that takes the vPE lock and then calls
+    a helper that takes the per-VM lock. The fix shape is to hoist the outer
+    lock into the caller, not to reorder locally.
+
+*   **VMOVP under ITSList is a serialization point.** When the ITSList feature
+    is in use, every ITS must observe VMOVP commands in the same order, so
+    `its_send_vmovp()` takes a global lock and stamps a sequence number around
+    the loop that emits one VMOVP per ITS. A change that narrows that lock to
+    the individual sends, or that emits VMOVPs from a second site, breaks the
+    ordering the feature requires.
+
+*   **Changing a vPE's affinity affects interrupts that are not the vPE.** The
+    driver spells this out: "changing the affinity of a vPE affects *other
+    interrupts* such as all the vLPIs that are routed to this vPE. This means
+    that the irq_desc lock is not enough to protect us". Any path that reads
+    `vpe->col_idx` must take the vPE lock, not merely the descriptor lock of
+    the interrupt it happens to be handling.
+
+*   **A VMOVP must not be issued for a vPE that is no longer mapped, and
+    `vmapp_count` is the guard.** Userspace can request an affinity change
+    against a doorbell interrupt that is still visible in `/proc/irq` after the
+    vPE has been unmapped. `its_vpe_set_affinity()` checks `vmapp_count`, which
+    `its_build_vmapp_cmd()` maintains on both the map and unmap paths and which
+    is common to GICv4.0 and GICv4.1.
+
+*   **Not-yet-mapped is a legitimate state under lazy mapping, and the guard
+    must say so.** With lazily-mapped vPEs a guest that has not yet issued a
+    MAPTI has no mapping, and an affinity change then is not an error: the
+    driver updates the effective affinity and returns without touching
+    hardware. Only the eager-mapping case fails. This distinction was itself a
+    regression introduced by the previous rule's fix, which is the reason to
+    check it: a new guard on a hardware-state predicate must enumerate the
+    states that are legitimately in that condition, not assume they are all
+    errors.
+
+*   **The doorbell request is one-shot and races the non-residency write.** The
+    doorbell can fire at any point after the write that makes the vPE
+    non-resident, including between that write and the update of the software
+    flag recording whether anything was pending — so the two must be
+    serialized, or a doorbell that arrives in the window is overwritten by the
+    stale value and the vCPU sleeps until something unrelated wakes it. GICv4.0
+    is not exposed to this because the doorbell is actively masked on guest
+    entry; GICv4.1 manages doorbell delivery in hardware, so the window is real
+    there.
+
+*   **Residency is driven by `vcpu_load()`/`vcpu_put()`, so it cannot be used
+    to infer intent to block.** A preemption between the put and the actual
+    schedule makes the vPE resident again on the way back in, at which point
+    the blocking path no longer requests a doorbell and the vCPU sleeps
+    unwakeable. The WFI emulation therefore records that it is entering WFI in
+    an explicit vCPU flag, sets the flag and performs the vGIC put together
+    under `preempt_disable()`, and keys the doorbell request on the flag rather
+    than on the residency state. Note that the same put serves two purposes at
+    once — syncing the priority mask back for the pending check, and requesting
+    doorbells — which is why a change to either concern has to be checked
+    against the other.
+
+*   **The ITS has no idempotent map.** Mapping a vLPI that is already mapped,
+    and unmapping one that is not, are both errors the caller must exclude
+    before issuing the command.
+
+**REPORT as bugs:**
+*   A `GICR_VPENDBASER` write that is not preceded by a wait for Dirty to
+    clear, or a write to any field other than `Valid` while `Valid == 1`.
+*   A vPE deschedule path that reports "nothing pending" when the Dirty state
+    left the answer unknown.
+*   A function that takes the per-vPE lock and then calls into something that
+    takes the per-VM `vmapp_lock`.
+*   A path that reads or acts on `vpe->col_idx` under only the interrupt
+    descriptor lock.
+*   A VMOVP emitted outside the serialized send path when ITSList is in use.
+*   A vLPI map issued without establishing that the vLPI is not already mapped.
+
+## LPI Lifetime and Reference Counting
+
+Every `struct vgic_irq` for an LPI is refcounted and lives in a per-VM xarray.
+The protocol around that refcount is where this subsystem's use-after-free bugs
+live, and it has enough structure that a reviewer can check a new call site
+mechanically. `kvm-arm64.md` covers the lock-ordering rules layered on top of
+this protocol; the rules below are about the protocol itself.
+
+> The failure mode throughout is use-after-free reached from a guest-triggerable
+> race: a guest issues a DISCARD for an LPI that is still queued on a vCPU and
+> immediately remaps the same INTID, or two vCPUs drain a translation cache
+> concurrently. The resulting frees are of objects another CPU is still walking.
+
+*   **A lookup must elevate the refcount before releasing whatever serializes
+    refcount changes.** Returning a pointer and taking the reference afterwards
+    leaves a window in which the object can reach zero and be freed. Both
+    lookups in the tree have the same shape — take RCU, load, attempt to take a
+    reference, and return `NULL` if the attempt fails:
+
+    ```c
+    /* CORRECT: the reference is taken before the lock is dropped */
+    rcu_read_lock();
+    irq = xa_load(&dist->lpi_xa, intid);
+    if (!vgic_try_get_irq_ref(irq))
+            irq = NULL;
+    rcu_read_unlock();
+    return irq;
+
+    /* WRONG: caller takes the reference after the lookup returns */
+    rcu_read_lock();
+    irq = xa_load(&dist->lpi_xa, intid);
+    rcu_read_unlock();
+    return irq;
+    ```
+
+*   **The refcount drop and the eviction from the container must be one atomic
+    step.** If the decrement happens outside the lock that guards the xarray,
+    a concurrent registration of the same INTID can insert a *new* object at
+    that key in the gap, and the releasing context then erases the new object
+    and frees the old one. `vgic_put_irq()` closes this with
+    `refcount_dec_and_lock_irqsave()` on the xarray lock, performing the
+    eviction only in the branch where the decrement reached zero and the lock
+    was taken.
+
+*   **Where the atomic form is unavailable, the API splits and the caller
+    inherits an obligation.** Callers already holding a raw spinlock cannot
+    take the xarray lock, so they use the no-release variant, which is marked
+    `__must_check`, accumulate its results across the loop, and call the
+    deferred release once the raw lock has been dropped. Both loops that do
+    this — the AP-list pruning path and the pending-LPI flush path — follow the
+    same shape. A new caller of the no-release variant that discards the return
+    value leaks the object permanently.
+
+    ```c
+    /* CORRECT: accumulate, then release outside the raw lock */
+    raw_spin_lock_irqsave(&vgic_cpu->ap_list_lock, flags);
+    list_for_each_entry_safe(irq, tmp, &vgic_cpu->ap_list_head, ap_list) {
+            ...
+            deleted |= vgic_put_irq_norelease(vcpu->kvm, irq);
+    }
+    raw_spin_unlock_irqrestore(&vgic_cpu->ap_list_lock, flags);
+    if (deleted)
+            vgic_release_deleted_lpis(vcpu->kvm);
+    ```
+
+*   **Orphans are identified by refcount, never by a flag on the object.** A
+    "release is pending" flag stored in the object is itself a use-after-free
+    once a concurrent path is allowed to free that object, which is why the
+    deferred-release walk tests the refcount directly and no such flag exists in
+    the structure. A patch that reintroduces one is reintroducing the bug.
+
+*   **A reservation taken before the lock is not a reservation that survives
+    the gap.** Pre-reserving an xarray slot outside the lock and then storing
+    under it with a zero gfp assumes nothing removed the node in between, and
+    something can: a concurrent release erases the entry and frees the node, and
+    the store then fails with `-ENOMEM`. The store under the lock passes a real
+    (non-sleeping) gfp for this reason.
+
+*   **When draining a container that other contexts may drain concurrently, put
+    what the erase returned, not what the iterator handed you.** The
+    translation-cache invalidation is reachable from three paths that hold three
+    different locks and exclude one another not at all. Each erases atomically
+    and drops the reference only for the entry it actually removed, under the
+    comment "Only the context that erases the entry drops its cache ref."
+    Putting the iterated pointer instead drops one cache reference several
+    times over.
+
+    ```c
+    /* CORRECT: only the context that removed the entry drops its reference */
+    xa_for_each(&its->translation_cache, idx, irq) {
+            irq = xa_erase(&its->translation_cache, idx);
+            if (irq)
+                    vgic_put_irq(kvm, irq);
+    }
+
+    /* WRONG: every racing context puts the same entry */
+    xa_for_each(&its->translation_cache, idx, irq) {
+            xa_erase(&its->translation_cache, idx);
+            vgic_put_irq(kvm, irq);
+    }
+    ```
+
+*   **A best-effort cache still has to balance its references.** The cache
+    insertion takes a reference, then drops it again if the store returned an
+    error, and separately drops the reference on any entry it displaced when
+    two CPUs raced to cache the same translation. Deliberately swallowing the
+    error — the cache is best effort, so the caller is not told — is correct and
+    is commented as such; leaking the reference is not.
+
+*   **`xa_release()` belongs outside the xarray lock.** The registration path
+    drops the lock before releasing a reserved-but-unused slot, which is why
+    that function is structured without a shared error label.
+
+*   **SPIs are bounded, LPIs are keyed.** The interrupt lookup range-checks SPIs
+    against the configured count and applies `array_index_nospec()` before
+    indexing the array, while LPIs go through the xarray. A new path that treats
+    an LPI INTID as an array index has chosen the wrong half of that function.
+
+*   **A guest-supplied INTID reaching an invalidation or self-injection
+    register must be sanitized in every dimension the emulation does not
+    implement.** The redistributor's LPI invalidate handler is the worked
+    example: it discards writes to the upper half of the register (those are for
+    vPEs, which the emulation does not support), returns early unless LPIs are
+    enabled, and rejects any INTID below the LPI base. Each of the three is a
+    separate check for a separate way the guest can name something the handler
+    was not written for. When reviewing a newly forwarded or newly emulated
+    register that carries an interrupt identifier, ask what the guest can make
+    the GIC do with an arbitrary value in each field; forwarding a raw value is
+    a decision to justify, not a default.
+
+**REPORT as bugs:**
+*   A lookup that returns an interrupt structure without having taken a
+    reference under the same lock or RCU section that made the lookup safe.
+*   A refcount decrement and a container eviction that are not a single atomic
+    step, or the decrement performed outside the lock the eviction needs.
+*   A discarded return value from the no-release put, or a raw-spinlock loop
+    that uses it without a following deferred release.
+*   Any per-object flag used to mean "this is awaiting release".
+*   A container drain that puts the iterated pointer rather than the value the
+    erase returned.
+*   An emulated register handler that accepts a guest-supplied INTID without
+    range-checking it and without rejecting the fields the emulation does not
+    implement.
+
+## The AP List and Interrupt Migration
+
+Each vCPU has an active-pending list of interrupts it is responsible for. The
+pruning walk migrates interrupts whose target has changed, and to do that it
+must drop and retake locks — which is where its bugs come from.
+
+> Every bug in this area is a use-after-free or a corrupted list reached by a
+> guest doing something ordinary at an unlucky moment: disabling LPIs on one
+> vCPU while another migrates an interrupt, or a maintenance interrupt arriving
+> slowly enough that the hardware state has moved on.
+
+*   **After retaking the locks, re-validate ownership as well as affinity.**
+    Checking only that the interrupt's target is still this vCPU is not enough,
+    because a concurrent path can take the interrupt off the list without
+    touching its target: the pending-LPI flush clears the owning vCPU pointer
+    but leaves enabled, pending and target state untouched, so the target oracle
+    still answers the same and the deletion runs a second time on an entry
+    already removed. The check must be "still targeted here **and** still ours".
+
+*   **Take a reference before dropping the locks.** With the locks dropped, the
+    interrupt can reach a zero refcount and be freed before the retry
+    reacquires them. The walk takes an explicit reference for the duration,
+    under the comment "make sure it is kept alive while locks are dropped".
+
+*   **Pending state is not carried across a migration.** There is no
+    architectural expectation that pending state survives a change of target,
+    so the migration path deliberately does not try to preserve it. A patch that
+    adds pending-state transfer to make migration "lossless" is adding
+    complexity for a property the architecture does not promise, and the
+    attempt to preserve it was itself part of a use-after-free.
+
+*   **Two-vCPU list locking is ordered by vCPU ID, smallest first**, with the
+    second acquired as a nested lock. Any new path that needs both lists must
+    use the same ordering rather than inventing one.
+
+*   **EOIcount deactivations must start after the last interrupt that made it
+    into the list registers.** EOIcount counts deactivations of interrupts that
+    are *not* in an LR. If the maintenance interrupt is slow enough that further
+    interrupts were activated out of the LRs before the exit, walking the AP
+    list from the head deactivates interrupts that are in LRs — the wrong ones —
+    and the guest loses interrupts. The walk therefore starts after a recorded
+    marker for the last interrupt loaded into an LR.
+
+*   **In the nested case the physical interrupt has already been deactivated by
+    the list register's hardware bit, and a second deactivate is not harmlessly
+    redundant.** The shared deactivation helper therefore performs the physical
+    deactivation only when the hardware bit is set *and* the vGIC is not in the
+    nested state. The reason it is not merely redundant is that on at least one
+    implementation, deactivating an interrupt that is not active but is the
+    highest-priority pending interrupt loses the pending state and prevents
+    delivery of future interrupts. Treat a duplicated deactivation as a defect
+    even where the architecture alone would tolerate it.
+
+**REPORT as bugs:**
+*   A revalidation after a lock drop that checks affinity but not continued
+    ownership.
+*   Any path that drops the interrupt lock and the list lock around a
+    manipulation without holding a reference across the gap.
+*   A second AP-list acquisition ordered by anything other than vCPU ID.
+*   An EOIcount deactivation walk that starts from the head of the list.
+
+## List Registers
+
+The list registers hold the virtual interrupts presented to a guest, and the
+architecture places uniqueness constraints on their contents. Two of those
+constraints are easy to conflate because they look alike and are in different
+sections.
+
+> Violating either uniqueness rule is UNPREDICTABLE, and the observed symptom is
+> a guest that locks up rather than anything that identifies the cause.
+
+*   **Two list registers must not hold the same virtual INTID unless both are
+    Invalid.** The architecture states that "Behavior is UNPREDICTABLE if two or
+    more List Registers specify the same vINTID when: • ICH_LR<n>_EL2.State ==
+    0b01. • ICH_LR<n>_EL2.State == 0b10. • ICH_LR<n>_EL2.State == 0b11." Only
+    the Invalid state is exempt. This is what makes multi-source software
+    interrupts awkward: distinct sources are architecturally distinct interrupt
+    events but must not occupy several list registers at once, so the emulation
+    injects one per entry and arranges a maintenance interrupt to deliver the
+    rest.
+
+*   **The physical INTID rule is a different rule.** In the separate list of
+    programming errors that result in UNPREDICTABLE behaviour, the architecture
+    names "Having two or more interrupts with the same pINTID in the List
+    registers for a single virtual CPU interface." Two list registers may carry
+    the same *physical* INTID in some other arrangement no more than they may
+    carry the same virtual one, but the two statements are in different
+    sections, constrain different fields, and cannot be cited for each other.
+    If a patch or review comment cites one section for the other's claim, the
+    citation is wrong even if the conclusion happens to hold.
+
+*   **The same programming-error list carries the hardware-bit consistency
+    rule.** It is an error to have a list register entry with the hardware bit
+    set, associated with a physical interrupt, in the active or pending state,
+    when the distributor does not have the corresponding physical interrupt in
+    the active or active-and-pending state. A mapped interrupt whose two halves
+    have drifted apart is therefore not merely inconsistent bookkeeping.
+
+*   **The list also constrains EOImode-0 operation**: it is an error to have an
+    active interrupt in the list registers whose priority is not set in the
+    corresponding active priorities register, or to have two active interrupts
+    with the same preemption priority.
+
+*   **GICv4 adds two more entries to that list**, both about the same virtual
+    interrupt arriving by two routes: a valid list register and an ITS mapping
+    for a vPE that use the same virtual INTID, and, under GICv4.1, a valid list
+    register whose virtual INTID is a software-generated interrupt that is also
+    generated for the vPE through the ITS. Code that can inject the same
+    interrupt through both the list registers and direct injection needs to
+    exclude the overlap.
+
+*   **Special INTIDs and the LPI range have their own constraints.** A virtual
+    INTID in 1020-1023 in a list register whose state is not Inactive is
+    UNPREDICTABLE, and specifying a virtual INTID in the LPI range while
+    `ICC_SRE_EL1.SRE == 0` is UNPREDICTABLE.
+
+**REPORT as bugs:**
+*   Any path that can place the same virtual INTID in two list registers in a
+    state other than Invalid.
+*   A list register with the hardware bit set whose physical counterpart is not
+    correspondingly active in the distributor.
+*   Injection of a virtual interrupt through the list registers for a vPE that
+    can also receive it through the ITS.
+
+## Mapped Interrupts
+
+A mapped interrupt is one whose state is partly in hardware: the guest's
+deactivation of the virtual interrupt also deactivates the physical one. That
+split is the source of a recurring family of stale-state bugs.
+
+> The state software holds and the state hardware holds can disagree at any
+> point where only one of them was updated, and the resulting symptoms are
+> spurious injections, interrupts that are lost across a reset, and — for the
+> priority-mask case — a vCPU that blocks forever.
+
+*   **Resample the hardware pending state on deactivation.** When the guest
+    deactivates a mapped level interrupt, the physical interrupt is deactivated
+    with it, but the software pending state may be stale: it was sampled at
+    entry and the guest may since have removed the condition. Without a
+    resample the interrupt is injected again spuriously.
+
+*   **The hardware pending state is readable only while the vCPU is loaded**,
+    so the userspace-facing accessor cannot be the guest-facing one. A userspace
+    read that falls through to the guest accessor reads hardware state from a
+    context where it is not available. The emulation keeps a separate
+    userspace read accessor for exactly this reason.
+
+*   **Mapped interrupts cannot be reset through the userspace path** because
+    their state lives in hardware; the owning subsystem (the architected timer,
+    today) resets them explicitly on VM reset instead. A patch that adds a
+    userspace reset path for them is working around the wrong end.
+
+*   **The guest's view of the priority mask is in hardware until the vCPU is
+    put, and the accessor reads a shadow copy.** `ICH_VMCR_EL2` is left loaded
+    across the run loop; `vgic_v3_get_vmcr()` reads `cpu_if->vgic_vmcr`, the
+    saved copy, not the live register. So any host-side computation that
+    depends on the guest's priority mask is reading whatever the last put
+    saved. The computation that matters is the pending check, which compares
+    `irq->priority < vmcr.pmr` — a guest that masks interrupts, is preempted
+    and rescheduled, then unmasks and executes WFI would otherwise be evaluated
+    against its old masked value, report nothing pending, and block with an
+    interrupt waiting. The WFI emulation therefore performs a full vGIC put
+    before halting rather than relying on the scheduler to do it, and says so:
+    "Sync back the state of the GIC CPU interface so that we have the latest
+    PMR and group enables." A new path that evaluates guest pending state while
+    the vCPU is still loaded reintroduces the stale read.
+
+*   **A virtual software-generated interrupt backed by GICv4.1 hardware needs
+    its pending state written through.** When userspace sets the pending state
+    of such an interrupt, leaving it in the software latch loses it, because the
+    interrupt is delivered from hardware. The write-through matters mainly
+    across a VMM-driven reset of a running VM, which is why it is easy to miss.
+
+**REPORT as bugs:**
+*   A mapped level interrupt deactivated without the software pending state
+    being resampled.
+*   A userspace accessor that reads hardware-resident interrupt state through
+    the guest-facing path.
+*   A host-side evaluation of the guest's priority mask on a path that can run
+    before the virtual control register has been synced back.
+
+## ITS Table Save and Restore
+
+KVM's ITS keeps its device and interrupt translation tables in guest memory in
+an architected format, so that migration can save and restore them. The restore
+side parses attacker-influenced data and is the natural place for validation to
+be missing.
+
+> A restore path that accepts what the live path rejects lets migration
+> introduce a state the guest could never have produced, and the values involved
+> — table sizes, event-ID widths, table offsets — are the ones that go on to
+> bound loops and index tables. A save path that writes a stale entry produces
+> an image that restores into something that was never live.
+
+*   **A restore path must reject what the live command path rejects.** The
+    device-table restore is the worked example: the live device-mapping command
+    refuses an EventID width wider than the virtual ITS advertises, and the
+    restore path did not, so an out-of-range width was stored and then converted
+    into an oversized table-scan range. The fix mirrors the live check, with the
+    comment "Mimic the MAPD behaviour and reject invalid EID bits". For any new
+    restore handler, put it side by side with the live handler for the same
+    object and enumerate what the live one refuses.
+
+*   **An unmap must invalidate the guest-memory entry, not only the in-kernel
+    object.** When a device is unmapped or a translation discarded, the
+    corresponding table entry in guest memory has to be cleared. Leaving it
+    valid means a subsequent save does not write it (the object is gone) while a
+    subsequent restore reads it (the memory still says valid), so a
+    save-and-restore cycle resurrects an entry that was never live.
+
+*   **Two-level table scans must stop at the end of the current level 2 table.**
+    The scan advances by an offset read out of each entry, and the remaining
+    length is unsigned: a large forward offset makes the subtraction wrap to a
+    huge positive value, and the scan continues from a bad guest address instead
+    of returning to the next level 1 entry. The check must come before the
+    subtraction:
+
+    ```c
+    /* CORRECT: bound first, then advance */
+    byte_offset = next_offset * esz;
+    if (byte_offset >= len)
+            break;
+    id  += next_offset;
+    gpa += byte_offset;
+    len -= byte_offset;
+
+    /* WRONG: unsigned len wraps and the scan walks off the table */
+    len -= next_offset * esz;
+    if (!len)
+            break;
+    ```
+
+*   **Guest-memory entry accesses go through helpers that check the declared
+    entry size against the type at the call site.** The ABI declares an entry
+    size per table; the C code passes a concrete type. A mismatch writes the
+    wrong number of bytes into guest memory, so the helpers assert the two agree
+    — at build time where there is only one ABI, and at run time where there
+    could be more. A new save or restore site that open-codes the guest access
+    loses that check.
+
+*   **A table walk that finds no interrupt for an identifier must continue, not
+    fail.** An LPI can be legitimately unmapped by a different ITS while a walk
+    is in progress, so both the move-all handler and the pending-table sync skip
+    such identifiers and carry on. Turning that into an error aborts a migration
+    for a state the guest is allowed to be in.
+
+**REPORT as bugs:**
+*   A restore handler that omits a validation its live counterpart performs.
+*   An unmap that frees the in-kernel object without clearing the corresponding
+    guest-memory table entry.
+*   Unsigned length arithmetic in a table walk performed before the bound is
+    checked.
+*   An open-coded guest-memory table access that bypasses the entry-size
+    checking helpers.
+
+## vGIC Creation, Readiness, and Teardown
+
+The vGIC is created, configured, made ready, and torn down through several
+ioctls and vCPU lifecycle hooks. Ordering and unwind bugs here are not about
+interrupt delivery; they are about a vCPU observing a half-built or half-torn
+distributor.
+
+> Publishing readiness before the state it advertises lets a vCPU enter the
+> guest against an unregistered MMIO region. Asymmetric unwind leaves
+> registrations behind for objects that no longer exist, which is a
+> use-after-free the next time anything walks them.
+
+*   **Readiness is published last, and the ordering is explicit.** The
+    distributor's ready flag must be set after the MMIO registration it
+    advertises. Setting it earlier and registering afterwards leaves a window
+    in which a vCPU can start running against a distributor whose MMIO is not
+    yet visible. The flag is published with a release store and consumed with
+    an acquire load, which is the detail to check when reviewing a change here:
+    the ordering used to be left implicit, borrowed from the full barrier
+    inside the MMIO registration's `synchronize_srcu()`, and was made explicit
+    afterwards. Borrowing it again would be a regression, and not only
+    stylistically — the GICv5 model registers no distributor MMIO region at
+    all, so on that path there is no `synchronize_srcu()` to borrow from.
+
+*   **Guest-visible addresses are fixed at creation, not at finalization.** The
+    CPU interface and redistributor addresses must be established when the vGIC
+    is created. Re-deriving or resetting them at finalize time changes state the
+    guest may already be using.
+
+*   **A failed initialization must not eagerly tear down**, and a failed vCPU
+    creation must unregister exactly what it registered. The recurring shape is
+    an unwind that is not the inverse of the setup: a redistributor left
+    registered for a vCPU that failed to be created, or a vCPU left associated
+    with a redistributor region across teardown. When reviewing a change to
+    either path, walk the setup and the unwind side by side and check that each
+    registration has exactly one matching unregistration on every exit.
+
+*   **The configuration lock's correct scope is not "always held".** It protects
+    vGIC state, but it must not be held across MMIO unregistration — one fix
+    added it around a CPU-interface teardown and another removed it from around
+    redistributor unregistration. The rule to apply is therefore about scope and
+    ordering against the KVM device machinery, not about presence: check what a
+    new critical section calls into, and specifically whether it can reach the
+    MMIO bus registration path.
+
+**REPORT as bugs:**
+*   A readiness or "initialized" flag set before the state it advertises is
+    published.
+*   An error path that leaves a redistributor or CPU interface registered for an
+    object that was not successfully created.
+*   A new configuration-lock critical section that spans a call into MMIO
+    registration or unregistration.
+
+## Priority, Groups, and Pseudo-NMI
+
+The GICv3 priority model carries the kernel's pseudo-NMI support, and it
+interacts with the security state in ways that are not visible at the call
+site. `arm64.md` owns the `ICC_PMR_EL1` synchronization rules; this section is
+about the value in the register and the ordering around acknowledgement.
+
+> Comparing priorities on the wrong scale misclassifies an NMI as a normal
+> interrupt or the reverse. Missing the synchronization between acknowledging an
+> interrupt and handling it lets the handler run against stale state, which for
+> IPIs means reading data the sender wrote before signalling.
+
+*   **There must be a context synchronization event between the acknowledge and
+    the handling, and it must not be left implicit.** Where the driver runs with
+    EOI mode 1 it writes the end-of-interrupt register right after the
+    acknowledge, and that write happens to provide the synchronization — but
+    where it does not, nothing else would. The ack-completion helper therefore
+    issues the barrier unconditionally, outside the conditional write. Pseudo-NMI
+    support originally missed this because it duplicated the acknowledge path
+    without the barrier.
+
+    ```c
+    /* CORRECT: the barrier is unconditional, the EOI write is not */
+    if (static_branch_likely(&supports_deactivate_key))
+            write_gicreg(irqnr, ICC_EOIR1_EL1);
+    isb();
+
+    /* WRONG: the barrier only happens in EOI mode 1 */
+    if (static_branch_likely(&supports_deactivate_key)) {
+            write_gicreg(irqnr, ICC_EOIR1_EL1);
+            isb();
+    }
+    ```
+
+*   **The IPI sender needs a barrier before the interrupt and one after.**
+    Stores to Normal memory that the receiving CPU will read must be made
+    visible before the interrupt is signalled — and it must be a `dsb`, not a
+    `dmb`, because a write to a system register is not a memory access and a
+    `dmb` does not order the memory stores against it. Afterwards, an `isb`
+    forces the system-register writes themselves to be executed. The receiving
+    side is not automatically safe either: a CPU can speculatively enter the
+    interrupt entry path and prefetch shared data before the acknowledge that
+    identifies the interrupt, so the ordering between reading the acknowledge
+    register and reading the shared data has to be established too.
+
+*   **Distributor priorities and CPU-interface priorities are two scales, and
+    the driver keeps two sets of constants for them.** Whether the two scales
+    coincide depends on `GICD_CTLR.DS` and `SCR_EL3.FIQ` together, and only one
+    of the three reachable combinations makes them differ: with security
+    enabled and Group 0 deliverable to the non-secure world, the interrupt
+    priorities are presented in the non-secure view (a written value
+    right-shifted by one with the top bit set) while `ICC_PMR_EL1` is not. The
+    driver resolves this once at init rather than at each use — `gic_prio_init()`
+    pre-converts the distributor-side constants into the non-secure view in
+    exactly that case, so that `dist_prio_irq` and `dist_prio_nmi` are always
+    the right values to program into `GICD_IPRIORITYR`/`GICR_IPRIORITYR0` while
+    the `GICV3_PRIO_*` constants remain the right values to compare against
+    `ICC_PMR_EL1` and `ICC_RPR_EL1`. Its explanatory comment carries the full
+    three-row table and is worth reading before touching anything here. The
+    reviewable rule is that a priority value must be used on the side it was
+    prepared for: a new distributor or redistributor priority write that uses a
+    raw `GICV3_PRIO_*` constant instead of the `dist_prio_*` variable is wrong
+    on precisely the configurations that are hardest to test on.
+
+*   **The software-generated interrupt ID field is four bits.** The
+    architecture defines "INTID, bits [27:24] — The INTID of the SGI", and the
+    driver's mask is correspondingly `0xf` shifted to bit 24. A wider mask, or a
+    signed one, lets an out-of-range value through — which matters most in the
+    KVM emulation of the register, where the value is guest-supplied.
+
+*   **A general system interrupt must never translate to a software-generated
+    one.** Software-generated interrupts are handled earlier in the domain
+    translation, so a later translation producing one indicates a firmware
+    description that is wrong. Report it explicitly rather than accepting it.
+
+*   **GICv3 system registers are only usable once the system register interface
+    has been enabled**, and every path that reaches code touching them must have
+    done so first: primary boot, secondary CPU bring-up, and resume from power
+    management. Accesses before that are UNDEFINED, and on a configuration where
+    nothing else enabled the interface earlier they crash the boot.
+
+*   **The driver must not assume it owns the non-secure side of a
+    two-security-state system.** Interrupt group configuration has to follow the
+    security state the hardware actually reports, including the case of a single
+    security state; getting it wrong means interrupts are simply never
+    delivered.
+
+**Do NOT flag:**
+*   A comparison of `ICC_RPR_EL1`'s value directly against a `GICV3_PRIO_*`
+    constant with no shift applied. Once the distributor-side constants have
+    been pre-converted at init, the CPU-interface scale is the one those
+    constants are already on, so the comparison is correct as written.
+
+**REPORT as bugs:**
+*   An interrupt acknowledge path where the synchronization before handling
+    depends on an EOI mode or another conditional write.
+*   An IPI send path that uses a `dmb`-class barrier to order Normal-memory
+    stores against the system-register write that signals the interrupt.
+*   A distributor or redistributor priority write that uses a CPU-interface
+    priority constant instead of the pre-converted distributor-side value.
+*   A software-generated-interrupt ID extracted with a mask wider than four
+    bits or with a signed type.
+*   Code that accesses GICv3 system registers on a path that can run before the
+    system register interface is enabled.
+
+## GICv5 Hardware Running a GICv3 Guest
+
+GICv5 hardware may implement a GICv3-compatible **virtual** CPU interface, so a
+GICv3-aware guest can run on a machine with no GICv3 anywhere in it. The
+boundary matters here because roughly half of this guide stops applying on such
+a system while the other half continues to apply unchanged. `gic-v5.md` covers
+the GICv5 side; what follows is what a reviewer holding the GICv3 model needs.
+
+> Assuming the compatibility extends past the CPU interface leads to review
+> comments asking for GICv3 system-level behaviour that no hardware on the
+> machine provides. Assuming it extends nowhere leads to the opposite: treating
+> the shared vgic emulation code as dead on such a system when it is exactly
+> what a compatibility guest runs on.
+
+*   **The compatibility is a virtual CPU interface and nothing else.** There is
+    no distributor, no redistributor, and no GICv3 ITS underneath: the guest's
+    entire MMIO view is emulated in software by the same vgic-v3 code a GICv3
+    host uses, while the physical routing beneath it remains native GICv5.
+
+*   **Consequently the driver-side rules in this guide do not apply on such a
+    system, and the emulation-side rules do.** The GICv3 host driver is not
+    probed at all, so the command queue, RWP polling and redistributor
+    programming sections describe hardware that is not present. The list
+    register rules, the LPI refcounting rules, the AP list rules and the ITS
+    table save and restore rules all continue to apply, because that code is
+    shared and is what the compatibility guest is running on.
+
+*   **The virtual EOI mode bit still selects between combined and split EOI,
+    exactly as on GICv3.** Under legacy operation the virtual control
+    register's EOI mode field is the one that decides: with it clear, a write
+    to the virtual end-of-interrupt register performs both priority drop and
+    deactivation (and accesses to the virtual deactivate register are
+    UNPREDICTABLE); with it set, the end-of-interrupt register drops priority
+    only and the deactivate register deactivates. So a compatibility guest
+    coupling the two is correct only in the first case, and checking the mode
+    bit is part of reviewing such a path. `gic-v5.md` covers what changes on
+    the native side.
+
+**REPORT as bugs:**
+*   Code that infers the existence of a GICv3 distributor, redistributor or ITS
+    from the presence of the GICv3 compatibility feature on GICv5 hardware.
+
+## Quick Checks
+
+*   **Locks belong at the top of a set of operations that all need them.** The
+    vCPU-affinity entry point takes its lock once at the top rather than having
+    each callee take it, because a callee that reads mapping state without the
+    lock races the unmap path. When a function's callees all need the same lock,
+    hoisting it is the fix, not sprinkling.
+*   **Devices sharing a device identifier share one device structure.** Devices
+    behind a PCI bridge, or on hardware that aliases identifiers, resolve to the
+    same ITS device, so lookup-then-allocate needs a per-ITS mutex or two
+    concurrent probes double-allocate. A shared device is deliberately never
+    freed, because its lifecycle is not tracked.
+*   **Page allocation helpers in this driver take an order, not a count.**
+    Passing 1 where 0 was meant allocates two pages and leaks one — check the
+    parameter's meaning at every call site rather than reading the argument as a
+    quantity.
+*   **The LPI free-range list must stay sorted ascending, or range merging
+    silently stops working.** The allocator keeps free LPI IDs as a list of
+    `{base, span}` ranges and relies on the sort order to coalesce adjacent
+    ranges on free. Break the order and nothing crashes and nothing is
+    reported: the ranges simply stop merging, so the free list fragments and
+    allocation of a large contiguous block starts failing on a system that has
+    plenty free. The release path maintains the invariant by walking backwards
+    to the insertion point rather than sorting, then attempting a merge against
+    **both** neighbours — a change that inserts without preserving the order,
+    or that merges against only the following neighbour, reintroduces the
+    fragmentation with no symptom at the point of the bug.
+*   **Interrupt-identifier exhaustion is an error to propagate.** Continuing
+    past a failed allocation with nothing allocated produces a device that
+    appears set up and delivers nothing.
+*   **Non-coherent designs need the table flushed before the base register is
+    written**, not after, and the GICv4 redistributor tables need the same
+    shareability and cacheability treatment as the GICv3 ones. The GICv4 half
+    was overlooked when non-coherent support was added, so a new table type is
+    the thing to check.
+*   **CPU hotplug notifier callbacks run in atomic context.** Allocations on the
+    per-CPU ITS initialization path must not sleep, which is easy to miss
+    because the same allocation is fine on the boot path.
+*   **An introspection path must not assume the interrupt it is walking still
+    exists.** The vgic debug iterator in `vgic-debug.c` walks INTIDs rather than
+    live objects, so a lookup partway through the walk can legitimately return
+    `NULL` — an LPI can be unmapped while the file is being read. Its show
+    function therefore looks the interrupt up, returns early if the lookup
+    fails, and puts a reference only on the path where it took one. Any new
+    read-only walker over interrupt state inherits all three obligations.
+*   **A userspace-reachable accessor must tolerate state that has not been
+    configured yet.** Userspace can read any register at any time, including
+    before the ioctls that configure the device have run; a guest cannot,
+    because it has to configure the device before using it. So a computed
+    read-side field must handle the unconfigured case rather than assume the
+    setup order. The redistributor type register's "last" bit is the worked
+    example: computing it dereferenced the redistributor region descriptor,
+    which userspace could read before any base address had been set. Note
+    which fix survived — the field was first dropped from the userspace view
+    entirely, and that was reverted a few months later in favour of making the
+    computation safe (the helper now returns false when the descriptor pointer
+    is null) so that the bit is architecturally correct for userspace too. Do
+    not cite the removal as precedent for hiding a field from userspace;
+    upstream's settled position is that compliance wins and the read side gets
+    hardened.
+*   **A userspace write handler must take the field from the value being
+    written.** Extracting it from the current register contents instead makes
+    the write a no-op that returns success — the identification register's
+    revision field had this bug, so userspace could never select a revision for
+    migration compatibility, and nothing reported an error.
+*   **A translation cache entry must not be created for a directly-injected
+    interrupt.** The cache is a software translation shortcut; an interrupt
+    delivered by hardware to a vPE does not go through it, and caching it
+    creates a reference to state the software path will not maintain.

--- a/kernel/subsystem/gic-v5.md
+++ b/kernel/subsystem/gic-v5.md
@@ -1,0 +1,1027 @@
+# GICv5 Subsystem Details
+
+This guide covers invariants and bug patterns for GICv5: the host irqchip
+driver (`drivers/irqchip/irq-gic-v5*.c`), the shared register and table
+definitions (`include/linux/irqchip/arm-gic-v5.h`), and the KVM GICv5 virtual
+interrupt controller (`arch/arm64/kvm/vgic/vgic-v5.c`,
+`arch/arm64/kvm/hyp/vgic-v5-sr.c`). It is derived from the merged upstream
+implementation, its fix history, and the Arm Generic Interrupt Controller
+Architecture Specification, GICv5 (ARM IHI 111701).
+
+GICv5 is a redesign, not GICv3 with additions. The single most productive
+source of both missed bugs and false reports in this area is a reviewer
+applying GICv3 reasoning to GICv5 code, so the first section is devoted to the
+assumptions that do not carry over. For GICv3/v4 (including a GICv3 guest
+running in compatibility mode on GICv5 hardware) see `gic-v3.md`; for the
+generic KVM/arm64 rules that the VGIC shares with the rest of KVM, including
+the existing VGIC CPU interface, LPI/vLPI and `ICH_HCR_EL2` trap-ordering
+sections, see `kvm-arm64.md`.
+
+The GICv5 code is young and still growing. Where this guide says an interface
+"does not exist yet", verify against the target tree's own code rather than
+assuming: the rule is about the shape the code must have, not about a snapshot
+of which files are present.
+
+## GICv3 Assumptions That Do Not Hold
+
+Reasoning about GICv5 by analogy with GICv3 produces two failure modes that are
+equally expensive: a real defect is waved through because the v3 mental model
+says the code looks right, and a correct construct is reported as a bug because
+it does not look like its v3 counterpart.
+
+> Applying the v3 model to v5 code causes **missed completion and ordering
+> bugs** (the barrier idioms are different), **spurious reports against correct
+> code** (the structures are owned differently), and **wrong fixes accepted into
+> the tree** (a v3-shaped remedy applied to a v5 mechanism).
+
+*   **There is no Distributor and no Redistributor.** A GICv5 system is one or
+    more Interrupt Routing Services (IRS), zero or more Interrupt Translation
+    Services (ITS), and zero or more Interrupt Wire Bridges (IWB). SPI
+    configuration is per-IRS and is reached through a select-then-program
+    register discipline, not through a single global `GICD_*` window. Each SPI
+    is owned by exactly one IRS; `gicv5_irs_lookup_by_spi_id()` in
+    `drivers/irqchip/irq-gic-v5-irs.c` is the lookup, and it returns `NULL` for
+    an SPI no IRS claims.
+*   **PPI state and configuration live in the CPU interface, as system
+    registers.** The `ICC_PPI_*_EL1` family (enable, pending, active, handling
+    mode, priority) replaces the per-PE `GICR_*` MMIO region, with `ICV_PPI_*`
+    as the guest view and `ICH_PPI_*_EL2` as the EL2 view. Consequently EL2
+    mediation of PPIs is sysreg trapping, and world switch is a sysreg walk
+    (`__vgic_v5_save_ppi_state()` / `__vgic_v5_restore_ppi_state()` in
+    `arch/arm64/kvm/hyp/vgic-v5-sr.c`), not an MMIO copy.
+*   **There are no list registers on the native path.** Native GICv5
+    virtualization uses memory-backed VM and VPE structures walked by the IRS,
+    direct virtual injection (DVI) for PPIs, and doorbells for a non-resident
+    VPE. `ICH_LR<n>_EL2` exists only under the GICv3 legacy extension (see
+    "GICv3 Legacy Compatibility" below).
+*   **The ITS has no command queue.** Configuration is a plain memory write to
+    an in-memory table entry followed by a register-driven cache invalidation.
+    There is no `MAPD`/`MAPTI`/`INV`/`SYNC` command ring, and no `DISCARD`: an
+    unmap is a `VALID = 0` write plus an invalidate. Do not look for command
+    construction, queue-wrap handling, or `GITS_CWRITER` analogues, and do not
+    report their absence.
+*   **`DSB` is not the completion primitive for a GIC system instruction; the
+    GIC synchronization barrier is.** GICv5 configuration is no longer a memory
+    store, so the GICv3 reflex of "write, then `DSB`, then read back" does not
+    transfer. Only the GSB is defined to complete Interrupt Effects:
+    `gsb_sys()` completes the Interrupt Effects of all prior GIC instructions,
+    `gsb_ack()` completes only those of prior acknowledge (`GICR`)
+    instructions. Both are defined in `arch/arm64/include/asm/barrier.h`. State
+    this as "a `DSB` alone is not sufficient" rather than "a `DSB` does
+    nothing": the architecture does order Interrupt Effects against a `DSB`,
+    and a message-passing sequence generally needs the `DSB` on the writing
+    side *and* the GSB on the reading side.
+*   **There is no IRS cache-invalidate register.** The IRS is the sole writer of
+    Interrupt State Table (IST) contents, so its primitive is a sync that drains
+    accepted events (`gicv5_irs_syncr()`), never an invalidate. Only the ITS,
+    which caches software-written translation tables, has invalidate registers.
+    Reporting "the IRS equivalent of `GICR_INVLPIR` is missing" is a false
+    positive.
+*   **Priority is five bits at the CPU interface, and there is no binary
+    point.** `ICC_IDR0_EL1.PRI_BITS` only ever reports 4 or 5 bits, the
+    preemption/subpriority split of `ICC_BPR*_EL1` is gone, and the running
+    priority is derived from a 32-bit active-priority bitmap (`ICC_APR_EL1`,
+    `ICH_APR_EL2`) rather than a set of `APnR` registers. An IRS may implement
+    fewer priority bits than the CPU interface (`IRS_IDR1.PRIORITY_BITS`,
+    minimum 1), which is why `gicv5_init_common()` computes the usable width as
+    `min_not_zero(cpuif_pri_bits, irs_pri_bits)`.
+
+**REPORT as bugs:**
+*   Code that reasons about GICv5 ordering from a `DSB` or from a
+    read-back-after-write of an IRS/ITS register, where a GSB or a `*_STATUSR`
+    poll is required.
+*   A GICv5 change that adds a GICv3-shaped construct with no GICv5 basis (a
+    command queue, an LPI configuration/pending table pair, a `GICD_CTLR.RWP`
+    analogue), or a commit message that justifies GICv5 behaviour by citing
+    GICv3 behaviour.
+
+## Typed INTIDs and Type Dispatch
+
+A GICv5 INTID is self-describing: bits [31:29] are the type and bits [23:0] are
+an ID within that type's own namespace. The three namespaces are independent
+and each is up to 24 bits wide, so the same numeric ID is a valid PPI, LPI and
+SPI simultaneously.
+
+> Confusing a full INTID with a bare hardware ID indexes the wrong element of a
+> per-interrupt array, dispatches to the wrong irqdomain, or silently addresses
+> a different interrupt. Type-checking without bounding the ID reads or writes
+> past the end of a fixed-size array.
+
+The encoding and its accessors are in `include/linux/irqchip/arm-gic-v5.h`:
+`GICV5_HWIRQ_TYPE` is `GENMASK(31, 29)`, `GICV5_HWIRQ_ID` is `GENMASK(23, 0)`,
+and the type values are `GICV5_HWIRQ_TYPE_PPI` (`0x1`), `_LPI` (`0x2`) and
+`_SPI` (`0x3`). Note that the type occupies bits [31:29], not the top nibble.
+KVM's constructors and accessors are in `include/kvm/arm_vgic.h`
+(`vgic_v5_make_ppi()`, `vgic_v5_get_hwirq_id()` and friends).
+
+*   **Dispatch on the type, index on the ID.** `handle_irq_per_domain()` in
+    `drivers/irqchip/irq-gic-v5.c` is the canonical shape: extract the type to
+    pick the irqdomain, extract the ID to pass as the hwirq. A function that
+    receives a full INTID and uses it directly as an array index or a bit
+    position is wrong even when the array is large enough, because the type
+    bits make every ID enormous.
+*   **A GICv5 type predicate is not a bounds check.** In `include/kvm/arm_vgic.h`
+    the GICv5 arm of `__irq_is_ppi()` is `is_v5_type(GICV5_HWIRQ_TYPE_PPI, i)`,
+    which tests the type field and nothing else. The GICv3 arm, by contrast,
+    tests a numeric range and therefore does bound the value. Any caller that
+    uses a PPI predicate to decide it may index a `VGIC_V5_NR_PRIVATE_IRQS`-sized
+    array must check the hardware ID against that bound itself. Clamping with
+    `array_index_nospec()` is not a substitute: it converts an out-of-range ID
+    into a valid index for a different interrupt rather than rejecting it.
+*   **GICv5 has no SGIs.** `__irq_is_sgi()` returns `false` unconditionally for
+    the GICv5 model; inter-processor interrupts are LPIs allocated out of the
+    LPI domain (`gicv5_irq_ipi_domain_alloc()`, `GICV5_IPIS_PER_CPU`). Code that
+    omits an SGI case in a GICv5 path is correct, and a report that GICv5 "does
+    not handle SGIs" is a false positive.
+*   **KVM supports 64 PPIs, deliberately.** `VGIC_V5_NR_PRIVATE_IRQS` is 64,
+    covering the architected PPIs only, and
+    `BUILD_BUG_ON(VGIC_V5_NR_PRIVATE_IRQS != 64)` in
+    `__vgic_v5_save_ppi_state()` pins the assumption. The upper bank
+    (`ICH_PPI_*1_EL2`, `ICH_PPI_PRIORITYR8..15_EL2`) is written to zero on
+    restore rather than being carried. Support for the 64 IMPLEMENTATION
+    DEFINED PPIs above that was removed on purpose because it could not be
+    tested; do not report the zero writes as lost state, and treat a patch that
+    reintroduces 128-PPI handling as needing an explicit justification.
+
+**REPORT as bugs:**
+*   Passing a full typed INTID where a hardware ID is expected, or vice versa,
+    across a function boundary. The tell is a value produced by
+    `vgic_v5_make_*()` or read from an acknowledge reaching an array index, a
+    bitmap position, or a `*_SELR` register field without a
+    `vgic_v5_get_hwirq_id()` / `FIELD_GET(GICV5_HWIRQ_ID, ...)` in between.
+*   A new consumer of `__irq_is_ppi()` / `irq_is_ppi()` on the GICv5 model that
+    indexes private-interrupt state without independently bounding the hardware
+    ID.
+
+## System Instructions, GSB, and Context Synchronization
+
+GICv5 configuration and state changes are issued as `GIC`/`GICR` system
+instructions rather than MMIO writes, and they complete asynchronously with
+respect to the instruction stream. Two different barriers are needed for two
+different questions, and neither substitutes for the other.
+
+> Missing completion means a disable does not take effect before the code that
+> depends on it runs, which breaks the lazy-disable contract and delivers
+> interrupts the driver believes it has masked. Missing context synchronization
+> means a subsequent instruction reads a stale system register, so a
+> configuration query returns the previous query's answer.
+
+*   **GSB completes GIC-instruction effects; ISB synchronizes the instruction
+    stream.** `gsb_sys()` and `gsb_ack()` guarantee that the Interrupt Effects
+    of prior GIC instructions have completed and prevent later loads, stores
+    and GIC instructions from starting early. They are not context
+    synchronization events. A result deposited in a system register by an
+    instruction, or a direct write to a `ICC_PPI_*` register, still needs an
+    `isb()` before the following instruction can rely on it.
+*   **The GICv5 self-synchronizing register list is short, and it is not the
+    GICv3 one.** GICv5 system registers otherwise follow the generic
+    architectural rule that a direct write needs a context synchronization
+    event before software can rely on its effect on later instructions. The
+    architecture carves out exactly three registers as self-synchronizing:
+    `ICC_PCR_EL3`, `ICC_PCR_EL1` and `ICV_PCR_EL1`. Nothing else is on that
+    list — in particular `ICH_VMCR_EL2` and `ICH_APR_EL2` are not, so a
+    hypervisor writing either and then relying on the new value in subsequent
+    instructions needs an `isb()`. Do not carry the GICv3 exceptions across:
+    that list (`ICC_PMR_EL1`, the `ICC_IAR*` reads) is a different list for a
+    different architecture. Note also that `ICH_VMCR_EL2.VPMR` being an alias
+    of `ICV_PCR_EL1.Priority` does not transfer the property — the carve-out is
+    granted to a direct write to `ICV_PCR_EL1`, and a write to `ICH_VMCR_EL2`
+    is not one.
+
+    What the architecture does *not* settle is the narrower question of whether
+    the virtual CPU interface itself observes such a write before the
+    synchronization event. Do not assert either answer in review.
+*   **Disabling needs completion; enabling does not.** The architecture
+    guarantees that the effects of a GIC system instruction complete in finite
+    time, which is all that is required when unmasking. Masking is different,
+    because the lazy-disable mechanism assumes the interrupt really is masked
+    when `irq_mask()` returns. In `drivers/irqchip/irq-gic-v5.c`,
+    `gicv5_iri_irq_mask()` issues `GIC CDDIS` followed by `gsb_sys()` while
+    `gicv5_iri_irq_unmask()` issues `GIC CDEN` with no barrier, and both carry
+    a comment naming the rule they rest on.
+*   **The finite-time guarantee covers GIC instructions, not direct writes to
+    PPI system registers, so the PPI paths are symmetric where the IRI paths
+    are not.** This is the trap: the asymmetry above rests on a guarantee that
+    does not extend to a `ICC_PPI_*` write, whose effects are explicitly *not*
+    guaranteed to complete in finite time without explicit synchronization.
+    That is why `gicv5_ppi_irq_mask()` and `gicv5_ppi_irq_unmask()` both end in
+    `isb()` — not because the enable also completes in finite time, but because
+    neither direction does on its own. Reasoning "an enable is fine without a
+    barrier" from the IRI path to the PPI path is therefore wrong, and a PPI
+    unmask that drops its `isb()` is a real finding (a core can go to idle with
+    the write still in flight).
+
+    ```c
+    /* CORRECT: an IRI disable is completed, an IRI enable need not be */
+    gic_insn(cddis, CDDIS);
+    gsb_sys();
+    ...
+    gic_insn(cden, CDEN);
+
+    /* WRONG: DSB does not complete a GIC instruction's effects */
+    gic_insn(cddis, CDDIS);
+    dsb(sy);
+    ```
+*   **A configuration query needs an ISB before its result is read.** The
+    `GIC CDRCFG` instruction deposits its answer in `ICC_ICSR_EL1`, so the
+    sequence is instruction, `isb()`, then read.
+    `gicv5_iri_irq_get_irqchip_state()` does exactly this, and then checks
+    `ICC_ICSR_EL1.F` before trusting the Pending and Active fields.
+*   **Configuration of an unreachable INTID fails silently.** An INTID that is
+    not implemented, not in the current domain, or not provisioned produces no
+    effect and raises no fault. `GIC CDRCFG` reporting `ICC_ICSR_EL1.F` is the
+    only way to discover it. A code path that programs an interrupt whose
+    reachability is not otherwise established, and does not read back, will
+    lose the configuration with no diagnostic. Conversely, do not report a
+    missing error check on `CDEN`/`CDDIS`/`CDPRI`/`CDAFF`: those instructions
+    have no status output to check.
+
+**REPORT as bugs:**
+*   A GIC system instruction whose effect a subsequent access depends on, with
+    no `gsb_sys()`/`gsb_ack()` between them, or with a `DSB` used in place of
+    one.
+*   A read of `ICC_ICSR_EL1` (or any system register written as the result of a
+    GIC instruction) without an intervening `isb()`.
+*   An `irq_mask()` implementation that returns without completing the disable.
+
+## Acknowledge, Priority Drop, and Deactivate Are Three Separate Steps
+
+GICv5 is structurally split-EOI: no instruction performs both priority drop and
+deactivation, and no ordering between them is mandated. `GICR CDIA` acknowledges
+(returning a packed valid/type/ID, setting Active and, for edge interrupts,
+clearing Pending). `GIC CDEOI` performs the priority drop and takes no INTID at
+all: it drops the domain's highest active priority. `GIC CDDI` deactivates a
+specific INTID, and for a routed interrupt — an SPI or an LPI — it is legal from
+any PE. That cross-PE property does not extend to PPIs: a `CDDI` naming a PPI
+that is outside the Current Interrupt Domain has no effect, so a PPI is in
+practice deactivated on the PE that owns it.
+
+> Deferring the priority drop until deactivation blocks every interrupt of equal
+> or lower priority for the whole duration of the handler. Because Linux
+> programs all interrupts at the same priority, that is a denial of service for
+> all other interrupts, not a latency nit.
+
+Everything in this section describes the native GICv5 instruction set. Under
+GICv3 legacy operation the GICv3 EOI model applies instead, including its
+combined drop-and-deactivate mode; see "GICv3 Legacy Compatibility" below.
+
+*   **The priority drop belongs immediately after the acknowledge, not in
+    `irq_eoi()`.** This was fixed upstream after the driver initially did the
+    drop as part of the EOI callback: with a long-running handler, or a
+    directly-entered guest holding an interrupt active, nothing else could be
+    signalled. `gicv5_handle_irq()` now issues `GICR CDIA`, `gsb_ack()`,
+    `isb()`, then `gic_insn(0, CDEOI)`, and only afterwards dispatches to the
+    handler. `gicv5_hwirq_eoi()` issues `GIC CDDI` alone.
+*   **Deactivation is what prevents re-signalling.** Since the drop happens
+    early, the interrupt cannot be signalled a second time only because it is
+    still Active until software deactivates it. A path that skips the
+    deactivate must have a reason for the interrupt to be deactivated elsewhere.
+*   **An interrupt forwarded to a guest is deactivated by the guest.**
+    `gicv5_ppi_irq_eoi()` returns early when `irqd_is_forwarded_to_vcpu(d)`,
+    leaving deactivation to the guest's own handling of the injected interrupt.
+    This is correct and mirrors GICv3; do not report the missing `CDDI`.
+*   **LPIs have an active state.** Unlike a GICv3 LPI, a GICv5 LPI cannot
+    retrigger while it is being handled, so `IRQD_RESEND_WHEN_IN_PROGRESS` is
+    meaningless on a GICv5 LPI and was removed from the ITS domain. Do not
+    report its absence, and question a patch that adds it back.
+
+**REPORT as bugs:**
+*   A GICv5 handler or irqchip that performs `GIC CDEOI` in the `irq_eoi()`
+    callback, or that couples the priority drop to deactivation in any way.
+*   A `GIC CDEOI` issued with a non-zero INTID operand, which suggests the
+    author believes it deactivates a specific interrupt.
+*   An acknowledge path that dispatches to a handler without `gsb_ack()` and
+    `isb()` after `GICR CDIA`.
+
+## IRS Register Programming: Select, Program, Poll
+
+Several IRS register groups are select-then-program: a selector register names
+the object, then configuration registers act on whatever is currently selected.
+The selection is per-IRS state, not per-CPU state, and each step completes
+asynchronously.
+
+> Two CPUs interleaving a select-then-program sequence on the same IRS
+> configure the wrong interrupt or the wrong PE. Failing to wait for completion
+> lets the next write land while the previous one is still in flight, which the
+> architecture does not define. Ignoring the validity result configures an
+> object that does not exist and reports success.
+
+*   **Serialize the whole sequence, not the individual writes.** The lock must
+    span selector plus configuration. `gicv5_spi_irq_set_type()` takes
+    `irs_data->spi_config_lock` (a `raw_spinlock_t`, initialized per IRS at
+    probe) and holds it across `IRS_SPI_SELR`, the completion wait,
+    `IRS_SPI_CFGR`, and the second wait. A patch that adds a new SPI
+    configuration register write must extend the same critical section, not
+    take its own.
+*   **Poll the matching `*_STATUSR` after each step.** The pairs are fixed:
+    `IRS_SPI_SELR` and the SPI config registers complete via
+    `IRS_SPI_STATUSR`, `IRS_PE_SELR` and `IRS_PE_CR0` via `IRS_PE_STATUSR`,
+    `IRS_IST_BASER` and `IRS_MAP_L2_ISTR` via `IRS_IST_STATUSR`, `IRS_SYNCR`
+    via `IRS_SYNC_STATUSR`, `IRS_CR0` via its own `IDLE` bit.
+    `gicv5_wait_for_op()` and `gicv5_wait_for_op_atomic()` in
+    `include/linux/irqchip/arm-gic-v5.h` wrap the poll and carry a 10ms timeout.
+*   **`IDLE` and `V` answer different questions.** `IDLE` means the register
+    write has completed; `V` means the selected object is valid. Both matter,
+    but not everywhere. `gicv5_irs_wait_for_spi_op()` checks `IDLE` then
+    requires `V`, because selecting an SPI this IRS does not own must fail.
+    `gicv5_irs_wait_for_irs_pe()` takes a `selr` flag and checks `V` only after
+    a selector write, because after an `IRS_PE_CR0` write there is no new
+    object to validate. That asymmetry is deliberate; a report that the `CR0`
+    path "forgets" the validity check is a false positive.
+*   **A poll timeout is an error, not a warning.** `gicv5_wait_for_op_s()`
+    returns `-ETIMEDOUT` after a rate-limited message. Callers must propagate
+    it and undo whatever they were setting up: `gicv5_irs_init_ist_linear()`
+    frees the table it had just published, `gicv5_irs_iste_alloc()` clears the
+    L1 entry it wrote and frees the L2 table.
+*   **The completion poll also provides the ordering against table memory.**
+    The MMIO accessors inside the poll supply the barriers that order CPU
+    accesses to a table against the IRS's accesses to it. This is why
+    `gicv5_irs_ist_synchronise()` is documented as the synchronization point
+    and why the post-sync cache maintenance in `gicv5_irs_iste_alloc()` is safe
+    where it sits.
+
+**REPORT as bugs:**
+*   A select-then-program sequence on an IRS register group with no lock, with
+    a lock that covers only part of the sequence, or with a lock that is not
+    the one the rest of that IRS's sequences use.
+*   A write to an IRS register with a defined `*_STATUSR` pairing that is not
+    followed by a completion poll before the next dependent access.
+*   A `gicv5_wait_for_op*()` return value that is discarded, or a failure path
+    that leaves a published table address or a half-written table entry behind.
+
+## Table Sizing: `n` Is an Alignment Exponent
+
+The GICv5 sizing expressions for the IST look like size computations and are
+not. `IRS_IST_BASER.ADDR` is `GENMASK_ULL(55, 6)`, and the architecture states
+the constraint as "bits [n:0] of the base address are zero", that is, an
+alignment requirement of 2^(n+1) bytes. The `Max(5, ...)` that appears in the
+expression is therefore a 64-byte alignment-granule floor and nothing more:
+there is no architectural minimum IST size, and no requirement that the
+allocation be 2^(n+1) bytes.
+
+> Getting this wrong in the shrinking direction gives the IRS a table smaller
+> than the ID space it was told to cover, so the IRS reads and writes memory the
+> driver did not allocate. Getting it wrong in the widening direction wastes
+> memory but is harmless, which is why over-provisioning is not a defect.
+
+*   **Allocating 2^(n+1) bytes is one correct way to satisfy the constraint,
+    not the constraint itself.** `gicv5_irs_init_ist_linear()` computes
+    `n = max(5, lpi_id_bits + 1 + istsz)` and allocates `BIT(n + 1)` bytes,
+    which is both large enough for `2^(LPI_ID_BITS + ISTSZ + 2)` bytes of
+    entries and, from a power-of-two allocator, suitably aligned. A table that
+    is larger than the ID space strictly requires is not a bug, and neither are
+    two sites that clamp the same expression differently, provided each site's
+    result is at least as large as what it is used to cover.
+*   **Validate the type as well as the value.** `BIT(n + 1)` is `1UL << (n+1)`;
+    assigning it to a `u32` truncates to zero at 32 and beyond, and
+    `kzalloc(0)` returns `ZERO_SIZE_PTR`, which is non-`NULL` and passes the
+    usual `if (!ptr)` check. The merged driver avoids this by using `size_t`
+    and by capping against `KMALLOC_MAX_SIZE` with an explicit warning that
+    reduces the advertised ID bits to match. A shift count that can reach or
+    exceed the width of the shifted type is undefined behaviour in the kernel;
+    `-fno-strict-overflow` does not cover it, and `CONFIG_UBSAN_SHIFT` exists
+    to detect it.
+*   **Unsigned sizing arithmetic can wrap past its own clamp.** In an
+    expression of the form `max(5, a - b + c)` with unsigned operands, a
+    negative inner result wraps to a very large value and `max()` selects the
+    wrapped value rather than the floor. When you see this shape, the question
+    to answer is whether the caller structurally guarantees `a > b`; if the
+    guard is in a different function from the arithmetic, say so, because that
+    separation is what makes the construct fragile even when it is currently
+    safe.
+*   **The size that is validated and the size that bounds the loop must come
+    from the same variable.** This is the highest-value structural check in
+    this area. Table geometry is recorded in more than one place at once: in the
+    configuration register the software wrote, and in the in-memory descriptor
+    the hardware walks. When a length check reads one and the copy or walk that
+    follows reads the other, anything that can make the two disagree turns the
+    check into a no-op. Trace both to their source and confirm they are the same
+    value, not merely two values that happen to be equal in the common case.
+
+    ```c
+    /* WRONG: validated against the register, copied according to the descriptor */
+    if (user_size != BIT(cfg_reg.id_bits) * sizeof(u32))
+            return -EINVAL;
+    for (i = 0; i < BIT(descriptor.id_bits); i++)
+            put_user(entry[i], &buf[i]);
+
+    /* CORRECT: one variable decides both */
+    n = BIT(descriptor.id_bits);
+    if (user_size != n * sizeof(u32))
+            return -EINVAL;
+    for (i = 0; i < n; i++)
+            put_user(entry[i], &buf[i]);
+    ```
+
+**Do NOT flag:**
+*   **`kmalloc()`/`kzalloc()` not guaranteeing alignment for a GIC table.** The
+    kernel's allocator contract, stated in
+    `Documentation/core-api/memory-allocation.rst`, is that "for sizes which are
+    a power of two, the alignment is also guaranteed to be at least the
+    respective size", and that for other sizes the alignment is at least the
+    largest power-of-two divisor. The IST and ITS table allocations are
+    power-of-two sized, so a 4KB allocation is 4KB-aligned and the low address
+    bits masked by `GICV5_ISTL1E_L2_ADDR_MASK` and friends are already zero.
+    An allocation whose size is *not* a power of two is a different matter and
+    is worth checking.
+*   **A table larger than the minimum, or two clamps that differ.** See above:
+    over-provisioning to an alignment granule is the intended behaviour.
+
+**REPORT as bugs:**
+*   `BIT(n)` or `BIT(n + 1)` assigned to a type narrower than the shift can
+    reach, or a table size that is not checked against an allocator limit.
+*   A length validation and the loop or copy it is meant to bound that read
+    their extent from different variables.
+
+## Who Owns the Valid Bit
+
+GICv5 in-memory structures are shared with hardware, and the architecture is
+specific about which side writes the valid bit. It is not the same answer
+everywhere, and getting it backwards in a review is the single most common
+false positive in this subsystem: automated reviewers repeatedly report "the
+code fails to set the VALID bit" against code that is correct precisely because
+it does not.
+
+> Software setting a valid bit that the IRS owns makes the behaviour of the IRS
+> Domain UNPREDICTABLE, and the only recovery is to invalidate an enclosing
+> structure — at best the affected VM, at worst the whole VM table or IST.
+> Software failing to set a valid bit it does own leaves the entry invisible to
+> hardware, and every interrupt covered by it is dropped.
+
+**For IRS-walked structures, the rule is path-dependent:**
+
+*   **Adding an entry to a structure that is already valid: software leaves the
+    valid bit at 0 and the IRS sets it** in response to the write of the
+    corresponding map register, then reports completion. This applies to a
+    level 2 IST published through `IRS_MAP_L2_ISTR`, a level 2 VM table
+    published through `IRS_VMAP_L2_VMTR`, and a virtual IST published through
+    `IRS_VMAP_VISTR`. The merged driver is a worked example:
+    `gicv5_irs_iste_alloc()` writes the L2 address into the L1 entry with the
+    valid bit clear, writes `IRS_MAP_L2_ISTR`, waits for
+    `IRS_IST_STATUSR.IDLE`, and its trailing comment says so explicitly ("Make
+    sure we invalidate the cache line pulled before the IRS had a chance to
+    update the L1 entry and mark it valid"). The same function *reads*
+    `GICV5_ISTL1E_VALID` to decide whether an L2 table already exists, which is
+    the correct use of a bit only hardware writes.
+*   **Providing an entry before the containing structure becomes valid:
+    software does write the valid bit.** A hypervisor populating a level 2 VM
+    table entry, including `L2_VMTE.LPI_IST_VALID` / `SPI_IST_VALID`, at the
+    moment the VM is made valid is architected, and is how a VM's virtual ISTs
+    are provided for migration and for suspend/resume. A tree with no such
+    prefill path will have a valid-bit macro that is defined and never used;
+    that is consistent with the architecture, not evidence of a bug.
+*   **That licenses pre-populating the table *entry*, not the IST's
+    *contents*.** The distinction matters because the two look alike in a diff
+    and only one of them is architected. Making an IST valid while it holds
+    non-zero Pending, HWU or metadata state is UNPREDICTABLE; the only sanctioned
+    way to install live interrupt state that way is an IMPLEMENTATION DEFINED
+    restore mechanism, which by definition cannot be assumed to exist on the
+    target implementation. The architectural migration path is instead: snapshot
+    the IST, record which interrupts were Pending, scrub the transient fields
+    (the specification's procedure zeroes Pending, HWU and metadata, and also
+    the affinity field for a 1-of-N interrupt where the IRS supports 1-of-N),
+    install the scrubbed image, make it valid, and only then re-inject each
+    recorded interrupt with `GIC VDPEND`. Note what that instruction names: a
+    VM identifier and an INTID, not a VPE. Valid VPEs are a *precondition* on
+    the destination VM — the re-injection must come after they are valid, or
+    the interrupts are not considered for those VPEs' virtual candidate
+    highest-priority pending interrupt. So a restore path that hands hardware a table
+    image with Pending bits still set is a real finding, while one that scrubs
+    and re-injects is correct even though it looks like it is "losing" state.
+*   **Writing a valid entry at all is UNPREDICTABLE.** Setting a valid bit into
+    a live entry, or updating a level 1 entry that is already valid, has
+    UNPREDICTABLE IRS Domain behaviour, and recovery is only ever by
+    invalidating some enclosing structure. Which structure depends on the
+    entry, and the granularity is worth getting right because a reviewer will
+    otherwise assume the cheapest one. A bad write to a level 1 IST entry is
+    recovered by invalidating the IST; to a level 1 VM table entry, by
+    invalidating the VM table; to a VPE table entry, by invalidating the VM.
+    The two level 2 VM table cases are the trap, because they differ from each
+    other: a bad write to a *valid* level 2 entry recovers at VM granularity,
+    while a write to an *invalid* level 2 entry that sets its valid bit
+    escalates to invalidating the whole VM table. The reason the coarser cases
+    are coarse is that the architecture provides no way to invalidate an
+    individual level 2 IST, an individual level 2 VM table, or an individual
+    VPE — a VPE can only be made invalid by making its VM invalid. So the
+    suggested "fix" of ORing the valid bit in is not merely unnecessary, it
+    introduces a defect, and it also makes the subsequent map-register write a
+    no-op because that write only has an effect on an entry that is currently
+    invalid.
+
+**For ITS tables, the opposite holds: software owns the valid bit.** The ITS
+has no map register; software writes the complete entry, valid bit included,
+and then invalidates. `gicv5_its_alloc_l2_devtab()`,
+`gicv5_its_device_register()`, `gicv5_its_create_itt_two_level()` and
+`gicv5_its_map_event()` in `drivers/irqchip/irq-gic-v5-its.c` all set
+`GICV5_DTL1E_VALID` / `GICV5_DTL2E_VALID` / `GICV5_ITTL1E_VALID` /
+`GICV5_ITTL2E_VALID` directly. Do not carry the IRS rule across to the ITS.
+
+**REPORT as bugs:**
+*   Software setting an IRS-owned valid bit (`L1_VMTE.VALID`,
+    `L2_VMTE.{LPI,SPI}_IST_VALID`, an L1 ISTE valid bit) on a structure that is
+    already valid, rather than letting the map register drive it.
+*   A map-register write with no preceding entry write, or an entry write with
+    no map-register write and no completion poll: either half alone leaves the
+    entry unpublished.
+*   An ITS table entry written without its valid bit, or written and never
+    invalidated.
+*   A restore path that makes an IST valid while the image it installed still
+    carries Pending, HWU or metadata state, without the target implementation
+    providing an IMPLEMENTATION DEFINED restore mechanism it can name.
+
+**Do NOT flag:**
+*   A defined-but-unreferenced valid-bit macro for an IRS structure, or an IRS
+    entry written without its valid bit and followed by a map-register write.
+    Both are the architected sequence.
+*   A migration path that scrubs Pending, HWU and metadata out of the IST image
+    it installs and replays the recorded pending interrupts with `GIC VDPEND`.
+    That is the architectural sequence, not lost state.
+
+## ITS: Publish Is Write, Invalidate, Then Sync
+
+Because there is no command queue, the ITS may hold cached copies of both valid
+and invalid table entries, and those caches are not affected by PE cache
+maintenance. A table write is therefore not visible to the ITS until an
+invalidation completes.
+
+> A mapping the ITS never observes silently drops every event for that device or
+> event. A stale cached translation delivers an event to an LPI that has been
+> freed and reused, which is a cross-device interrupt at best and, once the LPI
+> has been handed to a different driver, a corruption of that driver's state.
+
+*   **Every table entry write is followed by an invalidate and a completion
+    poll.** `its_write_table_entry()` does the `WRITE_ONCE` plus the cache
+    clean; the caller then invalidates by event (`gicv5_its_itt_cache_inv()`,
+    which writes `ITS_DIDR`, `ITS_EIDR`, `ITS_INV_EVENTR`) or by device
+    (`gicv5_its_device_cache_inv()`, `ITS_DIDR` plus `ITS_INV_DEVICER`), and
+    both end in `gicv5_its_cache_sync()` polling `ITS_STATUSR.IDLE`.
+*   **There is no unmap operation; unmap is `VALID = 0` plus invalidate.**
+    `gicv5_its_unmap_event()` clears `GICV5_ITTL2E_VALID` and invalidates;
+    `gicv5_its_device_unregister()` zeroes the whole DTE and invalidates.
+    Invalidation works irrespective of the values stored, which is why no
+    separate discard step exists.
+*   **Reusing a translation needs both syncs, in order.** Invalidation (a cache
+    operation) is a different tier from draining accepted events. Before an
+    LPI or an ITT entry can be safely reused, the accepted events must be
+    drained: `gicv5_its_irq_domain_free()` calls `gicv5_its_syncr()` for the
+    device and then `gicv5_irs_syncr()`, each polling its own
+    `*_SYNC_STATUSR.IDLE`. A free path that invalidates but does not sync can
+    hand a reused LPI an in-flight event from its previous owner.
+*   **Table entries are `__le64` and must be converted on read.** A bit test
+    against a raw `__le64` is a real bug on a big-endian build and was fixed
+    upstream in exactly this shape: `FIELD_GET(GICV5_ITTL2E_VALID, *itte)`
+    became `FIELD_GET(GICV5_ITTL2E_VALID, le64_to_cpu(*itte))`. Sparse catches
+    this, so the pattern to look for in review is a new accessor that
+    dereferences a `__le64` table pointer without `le64_to_cpu()`.
+
+**Do NOT flag:**
+*   A second invalidate immediately after a function that already invalidated.
+    One was removed upstream as redundant, and adding one back is noise, not
+    safety.
+
+**REPORT as bugs:**
+*   An ITS device-table or ITT entry modified without a following invalidate,
+    or invalidated without polling `ITS_STATUSR.IDLE`.
+*   An LPI, EventID or ITT freed or reused without the ITS sync and IRS sync
+    pair.
+*   A `FIELD_GET()` or bit test applied directly to a `__le64` GIC table entry.
+
+## Non-Coherent IRS and ITS
+
+An IRS or ITS may be non-coherent with the PEs, described by `dma-noncoherent`
+in DT or the corresponding MADT flag. The kernel handles this by programming
+non-cacheable memory attributes for the component and by doing explicit cache
+maintenance on the tables. What changes is the publish operation; the ordering
+requirements do not change.
+
+> Omitting the cache maintenance on a non-coherent system means the component
+> walks stale table contents: an entry the driver believes it wrote is not there,
+> or a stale entry it believes it cleared still is.
+
+*   **The publish step is conditional, the barrier is not.** Both
+    `gicv5_its_dcache_clean()` and the open-coded equivalents in
+    `irq-gic-v5-irs.c` select `dcache_clean_inval_poc()` when the component is
+    flagged non-coherent and `dsb(ishst)` otherwise. A new table write path must
+    go through the same helper rather than hardcoding either arm.
+*   **Reading back an entry the hardware wrote needs an invalidate, after the
+    completion poll.** On a non-coherent system the PE may have pulled a stale
+    copy of a line the IRS is about to update. `gicv5_irs_iste_alloc()` issues
+    `dcache_inval_poc()` on the L1 entry *after* `gicv5_irs_ist_synchronise()`
+    has returned, and comments that the poll's MMIO barriers are what keep the
+    invalidate from running early. An invalidate placed before the completion
+    poll would be useless.
+*   **Access attributes are programmed once, before anything is valid.**
+    `gicv5_irs_init_bases()` writes `IRS_CR1` and then enables the IRS via
+    `IRS_CR0.IRSEN`; `gicv5_its_init_bases()` writes `ITS_CR1` before allocating
+    the device table and enabling the ITS. Attributes take effect from the last
+    write made while no structure was valid, so a patch that adjusts `CR1` after
+    tables are live has no effect and should be questioned.
+
+**REPORT as bugs:**
+*   A new IRS or ITS table write path that uses `dsb(ishst)` unconditionally, or
+    that calls the CMO unconditionally, instead of branching on the component's
+    coherency flag.
+*   Cache maintenance for a hardware-written entry placed before, rather than
+    after, the completion poll that guarantees the hardware has written it.
+
+## Discovery Registers Report Width, Not Range
+
+Every GICv5 capability is discovered from an ID register field, and those
+fields are consistently wider than the values the architecture permits them to
+hold. Treating the field width as the value range produces confident,
+arithmetically correct, and wrong reports.
+
+> The false-positive direction wastes reviewer and maintainer time on
+> overflow claims that cannot occur. The false-negative direction is worse: code
+> that consumes a field without clamping it will misbehave on a
+> non-conforming or future implementation, and code that assumes two components
+> agree will size a structure for the wrong one.
+
+*   **Check the field's documented maximum before claiming a truncation.**
+    Worked examples from the GICv5 specification: `IRS_IDR3.VM_ID_BITS` is a
+    5-bit field, bits [9:5], whose minimum valid value is 8 and maximum is 16,
+    so a VM ID never needs more than 16 bits and a `u16` cannot lose one.
+    `IRS_IDR3.VMD_SZ` and `IRS_IDR4.VPED_SZ` have a maximum valid value of 12,
+    giving a maximum descriptor of 4096 bytes, so neither can produce a
+    zero-sized allocation by wrapping. `IRS_IDR2.MIN_LPI_ID_BITS` has a maximum
+    of 14 and is IMPLEMENTATION DEFINED, with the architecture noting that most
+    implementations are expected not to require a minimum at all. "The field is
+    N bits wide, therefore 2^N - 1 is reachable" is not a valid step.
+*   **Give every ID-register decode a defined fallback.** `gicv5_set_cpuif_pribits()`,
+    `gicv5_set_cpuif_idbits()` and `irs_setup_pri_bits()` all end in a `default:`
+    that logs and picks a safe value, because the architecture defines only a
+    subset of the encodings. A `switch` over an ID register field with no
+    `default`, or one that leaves the destination uninitialized, is a real
+    finding.
+*   **Capabilities are per-component and need not agree.** The number of INTID
+    ID bits is reported independently by the IRS (`IRS_IDR2.ID_BITS`) and the
+    CPU interface (`ICC_IDR0_EL1.ID_BITS`). The architecture only *recommends*
+    that components match, and separately recommends that the IRS support at
+    least as many bits as the PEs, so an IRS with more bits than the CPU
+    interface is explicitly the sanctioned direction and is not a mismatch to
+    report. Software that must work with both takes the minimum:
+    `gicv5_irs_init_ist()` caps `lpi_id_bits` by `cpuif_id_bits`, and
+    `gicv5_init_common()` takes `min_not_zero()` of the two priority widths.
+    Note also that the CPU interface can only report 16 or 24 ID bits while the
+    IRS reports a raw count, so they are not comparable encodings.
+*   **A policy cap is not an architectural cap, and must be re-applied
+    wherever the value can be set again.** When the driver or KVM narrows a
+    hardware-reported capability to its own limit, every later path that can
+    write that field has to apply the same limit, not merely the architectural
+    one. `vgic_v5_reset()` is the pattern: it pins the guest's view to
+    `ICC_IDR0_EL1_ID_BITS_16BITS` and 5 priority bits regardless of what the
+    host allows.
+
+**Do NOT flag:**
+*   A narrow C type holding an ID-register field whose architectural maximum
+    fits in it. Cite the maximum from the register description before deciding
+    either way.
+*   The IRS and the CPU interface reporting different ID-bit or priority-bit
+    widths.
+
+**REPORT as bugs:**
+*   A `switch` or decode over an ID-register field with no defined behaviour for
+    an unexpected encoding.
+*   A hardware capability consumed directly where the code has previously
+    narrowed it by policy, so the policy cap is bypassed on that path.
+
+## KVM: PPI State Lives in Hardware
+
+The merged GICv5 vGIC is PPI-centric. Private PPIs are the only interrupts it
+emulates; a GICv3-aware guest on GICv5 hardware runs on the existing vgic-v3
+stack as a compatibility device instead. Because the PPI state lives in the CPU
+interface rather than in KVM's own structures, the shadow `struct vgic_irq`
+state and the hardware registers must be reconciled on every entry and exit,
+and the direction of that reconciliation differs by handling mode.
+
+> Getting the reconciliation wrong loses interrupts outright. An edge that is
+> not transferred into the hardware pending register is never delivered; an edge
+> that is not cleared after transfer is delivered twice; a stale pending bit
+> written over a directly-injected PPI overwrites hardware-maintained state.
+
+*   **Iterate the exposed PPI mask, not the full range.** KVM exposes only a
+    handful of PPIs to a guest: the timers, the PMU interrupt and the software
+    PPI. `for_each_visible_v5_ppi()` (`arch/arm64/kvm/vgic/vgic.h`) walks
+    `gicv5_vm.vgic_ppi_mask`, and every state-folding, state-flushing,
+    pending-check and priority-sync loop in `vgic-v5.c` uses it. An earlier
+    implementation tried to detect which bits had changed instead, and that
+    lost edges the guest had not yet consumed, so the change-detection approach
+    was replaced by iterating the (small) exposed set unconditionally.
+*   **Edge and level pending are handled asymmetrically, in both directions.**
+    On the way in, `vgic_v5_flush_ppi_state()` builds the guest's pending
+    bitmap and clears `pending_latch` for edge interrupts, because the latch has
+    now been transferred to hardware and nothing else will lower it; a level
+    interrupt's pending state is driven by the line, so it is left alone. On the
+    way out, `vgic_v5_fold_ppi_state()` ORs the hardware pending bit into
+    `pending_latch` for edge interrupts only, and the OR is deliberate so that
+    an edge injected in software while the guest was running is not lost. Both
+    halves were upstream fixes. A patch that makes either direction symmetric
+    across handling modes is almost certainly wrong, and a report that the fold
+    "should use LEVEL" has read the condition backwards.
+*   **Directly-injected PPIs are excluded from the pending write-back.** DVI
+    aliases the physical PPI's pending state into the virtual PPI in hardware,
+    so KVM must not also write that PPI's pending bit on restore.
+    `__vgic_v5_restore_ppi_state()` computes `bitmap_andnot(pendr, ..., dvir)`
+    and writes only the non-DVI'd bits. DVI is disabled (`ICH_PPI_DVIR*_EL2`
+    zeroed) on save and re-enabled from the shadow on restore.
+*   **The DVI bitmap needs atomic bit operations.** Individual bits are each
+    protected by their own `vgic_irq->irq_lock`, but the bitmap as a whole has
+    no lock, so concurrent updates to different PPIs race. `vgic_v5_set_ppi_dvi()`
+    uses `assign_bit()`, not `__assign_bit()`; the non-atomic version was an
+    upstream bug. This generalizes: a per-interrupt lock does not serialize a
+    shared bitmap indexed by interrupt.
+*   **VM-wide finalization must be locked and idempotent.** `vgic_v5_finalize_ppi_state()`
+    runs per-vCPU but computes VM-wide state, so it takes
+    `kvm->arch.config_lock` and returns early if it has already run; without
+    both, two vCPUs race and one zeroes the mask the other is populating.
+*   **Residency is tracked in software and the entry points are re-entrant.**
+    `vgic_v5_load()` and `vgic_v5_put()` are each called twice around WFI, so
+    both begin with a `cpu_if->gicv5_vpe.resident` check and return early on the
+    redundant call, which is what prevents the saved VMCR from being clobbered
+    by a second save. A finding that `vgic_v5_load()` unconditionally makes the
+    VPE resident has quoted the body without the guard above it.
+*   **Priority comparison is a strict inequality.** An interrupt is signalled
+    only if its priority is numerically less than the effective mask;
+    `vgic_v5_has_pending_ppi()` uses `irq->priority < priority_mask` after an
+    upstream fix, because `<=` produced spurious wakeups at the limit. The mask
+    itself is `min(highest_active_priority, VPMR + 1)`, and is zero when the
+    guest has not enabled interrupt delivery, which short-circuits the whole
+    check.
+
+**REPORT as bugs:**
+*   A GICv5 PPI state path that iterates `VGIC_V5_NR_PRIVATE_IRQS` directly
+    instead of the exposed mask, or that reintroduces change-detection over the
+    pending bitmap.
+*   An edge-triggered PPI whose `pending_latch` is not cleared after being
+    flushed to hardware, or whose hardware pending bit is assigned rather than
+    ORed when folded back.
+*   A pending write-back that does not exclude DVI'd PPIs.
+*   A non-atomic bitmap operation (`__set_bit()`, `__assign_bit()`,
+    `__clear_bit()`) on a per-vCPU or per-VM interrupt bitmap whose only
+    claimed protection is a per-interrupt lock.
+*   VM-wide vGIC state computed from a per-vCPU entry point without
+    `config_lock` and without an already-done check.
+
+## Userspace-Facing and Save/Restore Paths
+
+KVM's VGIC register emulation gives each register up to four handlers: a guest
+read and write, and optional userspace read and write overrides
+(`uaccess_read` / `uaccess_write` in `struct vgic_register_region`,
+`arch/arm64/kvm/vgic/vgic-mmio.h`). The override exists because restore
+legitimately needs to do things a guest may not: program a table base before
+the tables exist, write a field the guest-side handler would refuse while some
+other state is live. That is a correct design, and it is also a systematic
+source of defects, because each override silently drops whatever the guest-side
+handler was doing beyond the bare field write.
+
+> A userspace path that accepts a register write the guest path would have
+> refused, validated, or acted upon leaves the emulated device in a state the
+> guest path can never produce. The consequences observed in practice are a
+> field restored past the cap the emulation advertises, a table marked valid
+> with no table behind it, and a configuration write accepted and discarded so
+> the setting is silently lost across migration.
+
+*   **Review overrides pairwise, and enumerate.** For each register with a
+    userspace override, put the guest handler and the userspace handler side by
+    side and ask what the guest handler does that the override does not:
+    refuse under some condition, allocate or free something, clamp a field,
+    request a reload, or set derived state. Then check the other direction:
+    a userspace *read* override that returns a different value from the guest
+    read is only a problem if that value can be fed back on restore, so a
+    register that is write-ignored on every path cannot be misled by it. Doing
+    this exhaustively over the register table, and saying how many registers
+    were compared, is what turns "there are some divergences here" into a claim
+    a maintainer can act on.
+*   **The fix is usually a post-condition, not the missing guard.** Adding the
+    guest-side guard to the userspace path breaks restore, because the
+    documented restore sequence depends on the guard being absent. What is
+    actually missing is a validation step at the *end* of restore that
+    re-establishes the invariants the guest path maintains continuously: that
+    the configuration register and the descriptor the hardware walks agree, that
+    a "valid" flag matches whether the backing object exists, that every
+    restored field is within the cap the emulation advertises. Recommending the
+    guard is the fix that gets sent back.
+*   **A register that is accepted and discarded is worse than one that is
+    rejected.** A `case X: break;` in a userspace write handler, with no
+    comment, means userspace's value is silently dropped: the setting does not
+    survive migration and userspace has no way to find out. Either the write
+    must take effect or it must be rejected.
+*   **A read-only attribute must reject writes, and the rejection must be
+    tested.** The merged GICv5 KVM device has one attribute of this kind,
+    `KVM_DEV_ARM_VGIC_USERSPACE_PPIS`, documented in
+    `Documentation/virt/kvm/devices/arm-vgic-v5.rst` as read-only with attempts
+    to set it rejected.
+*   **Every documented error code must be reachable, and every reachable one
+    documented.** When reviewing a new device attribute, walk the documented
+    error table against the code. An error branch that cannot fire, because an
+    earlier validation already excluded its precondition, is a documentation
+    bug and often reveals a parameter that has no effect at all.
+
+**REPORT as bugs:**
+*   A userspace write override that omits an allocation, free, clamp, reload
+    request or refusal performed by the guest-side handler for the same
+    register, with no restore-time step that re-establishes the same invariant.
+*   A restore path with no final self-consistency check across the state it
+    just wrote.
+*   A userspace write case that accepts a value and discards it.
+*   A device attribute documented as read-only whose set path does not return an
+    error.
+
+## Native Virtualization: Doorbells and VPE Configuration
+
+Merged KVM carries no doorbell handling — `struct gicv5_vpe` in
+`include/linux/irqchip/arm-gic-v5.h` holds only `bool resident` — so this
+section is architectural rather than code-anchored. Use it to review new code
+against the architecture, and verify the specifics against the target tree's
+own code rather than against anything stated here about which interfaces
+exist.
+
+> A missed doorbell means a vCPU blocked in WFI is never woken for an interrupt
+> that is already pending, which is an indefinitely hung guest rather than a
+> latency problem.
+
+*   **The doorbell condition is a predicate over current state, not an edge.**
+    A VPE doorbell is generated when the VPE is non-resident, its doorbell
+    settings are valid, a doorbell is requested, and there exists a qualifying
+    interrupt that is Pending, Inactive and Enabled at or above the doorbell
+    priority mask. Because it is a standing condition re-evaluated on any
+    configuration change, making a VPE non-resident with a doorbell requested
+    while an interrupt is already pending generates the doorbell immediately.
+    So "the interrupt became pending just before the arming write, therefore the
+    wakeup is lost" is not a real race, and reporting it is a false positive.
+*   **Requesting a doorbell and configuring one are different steps.**
+    `ICH_CONTEXTR_EL2.DB` on the write that makes the VPE non-resident and
+    `IRS_VPE_DBR.REQ_DB` are two routes to the same architectural "requested"
+    state, not two arms that must both be set, so code that sets only the former
+    at deschedule time is correct. What *is* separately required is that the
+    VPE's doorbell settings are valid, and they are not valid when a VPE is
+    created: they become valid only after the VPE is selected and
+    `IRS_VPE_DBR` is written, and a VPE becoming valid resets its configuration
+    so that it has no doorbell settings at all. Therefore the `IRS_VPE_DBR`
+    write must be redone after **every** VPE creation or revalidation,
+    including a vCPU reset, not once at setup.
+*   **A permissive doorbell priority mask is the correct default.** The
+    condition is "priority greater than or equal to the doorbell priority mask",
+    so leaving the mask at zero means every interrupt generates a doorbell. A
+    zero mask is not an unconfigured field.
+*   **Doorbells are one-shot.** The request self-clears when the doorbell is
+    generated, so it must be re-requested on each deschedule. A doorbell arrives
+    as an ordinary physical LPI in the VPE's own domain, not on a special
+    exception path.
+*   **A VPE's descriptor memory must be zero when the VPE becomes valid.** The
+    architecture states this as an expectation rather than a prohibition, but
+    it attaches two consequences that make it a requirement in practice: the
+    VPE's configuration, doorbell settings included, is reset to UNKNOWN
+    values, and it becomes CONSTRAINED UNPREDICTABLE *whether* the IRS Domain
+    selects a virtual candidate HPPI for that VPE at all. Note the term:
+    a *candidate* HPPI is the per-VPE nominee, distinct from the HPPI finally
+    selected among candidates, and the CONSTRAINED UNPREDICTABLE is about
+    whether one is nominated, not about which one. This is a
+    zero-initialization requirement on the allocation, so the thing to check is
+    the allocator: a descriptor obtained with a non-zeroing allocator, or
+    reused from a previous VPE without being cleared, meets it in neither case.
+
+**REPORT as bugs:**
+*   VPE doorbell configuration performed once at setup rather than after every
+    VPE validation, including after a vCPU reset.
+*   A blocked-vCPU wakeup path whose only signal is the doorbell, with no
+    re-request after the doorbell fires.
+*   A VPE made valid over descriptor memory that was not zero-initialized.
+
+## GICv3 Legacy Compatibility
+
+GICv5 hardware may implement `FEAT_GCIE_LEGACY`, which provides a
+GICv3-compatible **virtual** CPU interface. It is not a general compatibility
+mode: `FEAT_GCIE` excludes `FEAT_GICv3`, so there is no legacy physical CPU
+interface, and nothing in the IRS, ITS or IWB emulates a GICD/GICR/GICv3-ITS
+memory map. A GICv3 guest's MMIO view is therefore emulated entirely in
+software, by the existing vgic-v3 code, while the physical routing underneath
+remains native GICv5.
+
+> Assuming legacy support extends beyond the virtual CPU interface leads to code
+> that expects hardware to provide a GICv3 system view that does not exist.
+> Assuming its absence leads to a guest taking undefs on GICv3 registers the
+> host could have trapped and emulated.
+
+*   **Discovery is `ICC_IDR0_EL1.GCIE_LEGACY`, read directly.**
+    `test_has_gicv5_legacy()` in `arch/arm64/kernel/cpufeature.c` gates on
+    `ARM64_HAS_GICV5_CPUIF` and then reads the field, populating
+    `ARM64_HAS_GICV5_LEGACY`. Note the cpucap is an early local-CPU feature;
+    code that runs before capabilities are finalized must use
+    `cpus_have_cap()` rather than `cpus_have_final_cap()`.
+*   **The GIC maintenance interrupt exists if and only if `FEAT_GCIE_LEGACY`
+    does.** On a PE implementing `FEAT_GCIE`, PPI 25 (GICMNT) is implemented
+    when `FEAT_GCIE_LEGACY` is implemented and is not implemented otherwise;
+    `FEAT_GCIE_LEGACY` implies `FEAT_EL2`, but not the converse, so a
+    `FEAT_GCIE` + `FEAT_EL2` PE with no legacy support is architecturally valid
+    and has no GICMNT. An unimplemented PPI is RAZ/WI through the PPI system
+    registers and can never become pending. This is why the driver does not
+    treat a missing maintenance interrupt as fatal. It is also why a firmware
+    description that omits the maintenance interrupt is not a kernel bug: the
+    kernel discovers GICMNT's existence from `ICC_IDR0_EL1.GCIE_LEGACY`, not
+    from DT or ACPI.
+*   **The two worlds are mutually exclusive at EL1, and the switch is
+    `ICH_VCTLR_EL2.V3`.** Under legacy operation the native GICv5 instructions
+    and registers are UNDEFINED at EL1 and `ICH_VMCR_EL2` takes the GICv3 field
+    layout. Consequently a hypervisor that runs both kinds of guest must
+    explicitly leave legacy mode before restoring native state:
+    `__vgic_v5_restore_vmcr_apr()` calls `__vgic_v5_compat_mode_disable()`,
+    which clears `ICH_VCTLR_EL2.V3` and issues an `isb()` before writing
+    `ICH_VMCR_EL2`. Dropping that clear, or the `isb()`, means the subsequent
+    `ICH_VMCR_EL2` write is interpreted in the wrong layout.
+*   **Registration is additive and independently gated.** `vgic_v5_probe()`
+    registers `KVM_DEV_TYPE_ARM_VGIC_V5` and then, separately, registers
+    `KVM_DEV_TYPE_ARM_VGIC_V3` in compatibility mode if
+    `ARM64_HAS_GICV5_LEGACY` is set, enabling the GICv3 CPU interface traps via
+    `vgic_v3_enable_cpuif_traps()` so a compat guest does not take an undef on a
+    trapped register. Either registration can be skipped: pKVM currently skips
+    the native GICv5 device entirely, and a probe returns `-ENODEV` only if
+    neither device registered. When reviewing this function, check that the
+    max-vCPU limit and the capability flags are consistent with which devices
+    were actually registered on the path taken.
+*   **No native virtualization implies no legacy.** The architecture forbids the
+    combination, so `gic_of_setup_kvm_info()` returns without publishing
+    anything to KVM when `IRS_IDR0.VIRT` says the implementation is not
+    virtualization-capable. Note the polarity of that read: an inverted `!` on
+    it was an upstream bug (`gicv5_global_data.virt_capable = !FIELD_GET(...)`
+    where `!!` was meant), which is worth remembering as the shape to look for
+    whenever a boolean capability is derived from `FIELD_GET()`.
+
+**Do NOT flag:**
+*   A legacy-mode path that performs priority drop and deactivation in one
+    operation **when `ICH_VMCR_EL2.VEOIM` is 0**. In that mode a write to
+    `ICV_EOIR0_EL1` / `ICV_EOIR1_EL1` does both, exactly as on GICv3, and
+    accesses to `ICV_DIR_EL1` are UNPREDICTABLE — so a hypervisor emulating
+    this cannot treat `ICV_DIR_EL1` as merely inert either.
+
+    Check the mode bit before applying this, because the exemption is
+    conditional. With `VEOIM == 1` the split is back even in legacy mode:
+    `ICV_EOIR<n>_EL1` performs the priority drop only and `ICV_DIR_EL1`
+    deactivates, so a legacy path that couples the two at `VEOIM == 1` is a
+    real finding. What is native-GICv5-only is that the split is
+    **unconditional** — the GICv5 form of `ICH_VMCR_EL2` has no `VEOIM` field
+    at all, so there is no mode in which `GIC CDEOI` deactivates. Legacy mode
+    makes the split a mode; native GICv5 makes it structural.
+
+**REPORT as bugs:**
+*   Code that infers a GICv3 system-level view (a distributor, a GICv3 ITS, a
+    GICv3 physical CPU interface) from `FEAT_GCIE_LEGACY`.
+*   A native GICv5 guest-state restore that does not clear `ICH_VCTLR_EL2.V3`,
+    or that does so without a context synchronization event before writing
+    GICv5-layout registers.
+*   `cpus_have_final_cap(ARM64_HAS_GICV5_LEGACY)` on a path that can run before
+    capabilities are finalized.
+*   A boolean capability assigned from `FIELD_GET()` with a single `!` where the
+    sense should be `!!`.
+
+## Quick Checks
+
+*   **Tables handed to hardware and never freed need `kmemleak_ignore()`.** The
+    IST allocations are reachable only by physical address from the GIC, so
+    kmemleak reports them as leaks. `gicv5_irs_init_ist_linear()` and
+    `gicv5_irs_iste_alloc()` mark them after the publish has succeeded, which is
+    the right point: before the publish, the failure path really does free them.
+*   **Do not `WARN()` on a firmware-described value.** A malformed DT phandle
+    is a firmware bug and warrants `pr_warn(FW_BUG ...)`, not a backtrace; a CPU
+    node with no logical ID is not an error at all when the kernel was booted
+    with a restricted CPU count. Upstream removed both `WARN_ON()`s from the
+    IRS affinity parsing for exactly these reasons. Reserve `WARN()` for
+    conditions that indicate a kernel bug.
+*   **Error unwind in a domain allocation loop must cover previous
+    iterations.** `gicv5_irq_lpi_domain_alloc()` shows the shape: it allocates
+    an LPI and an L2 IST entry per interrupt, and on failure releases the LPI it
+    had just taken and then calls `gicv5_irq_lpi_domain_free()` for the `i`
+    interrupts already set up. Both halves are needed. The ITS twin,
+    `gicv5_its_irq_domain_alloc()`, is where getting only one of them was an
+    upstream bug: its unwind freed the in-flight LPI but left the earlier
+    iterations' LPIs and parent irqs allocated, and the fix rewrote it to walk
+    back over them.
+*   **A loop counter used in a reverse cleanup loop must be signed.** A
+    `for (i = i - 1; i >= 0; i--)` over an `unsigned int` never terminates; this
+    was a real fix in the ITS ITT cleanup path.
+*   **`gicv5_irs_lookup_by_spi_id()` can return `NULL`** for an SPI outside
+    every IRS's range, and it is stored as the irq chip data. Check new
+    dereferences of an SPI's chip data.
+*   **The IWB never targets SPIs.** An IWB turns wires into ITS events, which
+    the ITS translates into LPIs like any MSI. The whole IWB presents a single
+    DeviceID and each wire index *is* the EventID, which is why
+    `gicv5_iwb_write_msi_msg()` is an empty stub: the mapping is fixed in
+    hardware and the MSI domain template merely requires the callback. Do not
+    report the empty stub as unimplemented.
+*   **The IWB must already be enabled by firmware.** `gicv5_iwb_init_bases()`
+    fails probe if `IWB_CR0.IWBEN` is clear rather than setting it, and
+    zero-initializes every `IWB_WENABLER<n>` before waiting on
+    `IWB_WENABLE_STATUSR`.
+*   **A GICv5 PPI's trigger type is fixed in hardware.** `gicv5_ppi_irq_set_type()`
+    exists only so that a hierarchy can be built on top of the PPI domain; it
+    validates the requested type against `ICC_PPI_HMR<n>_EL1` and configures
+    nothing. A patch that makes it actually program the handling mode is wrong.
+*   **`ICC_PPI_*` register selection is by bank, and the banks are 64 bits.**
+    The `irq < 64 ? ..._EL1 : ..._EL1` pattern with `BIT_ULL(irq % 64)` appears
+    throughout; a bank index computed without the corresponding bit-position
+    modulo, or vice versa, addresses the wrong PPI. The same shape appears in
+    KVM's priority register handling, where each register holds eight five-bit
+    fields at byte granularity (`pri_reg = i / 8`, `pri_bit = (i % 8) * 8`).
+*   **`vgic_v5_probe()` is the only gate for GICv5 guests.** pKVM skips native
+    GICv5 registration entirely today, so a change that assumes a GICv5 vGIC is
+    available under protected mode needs that gate revisited first.

--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -84,6 +84,7 @@ and symbols regexes.
 | ARM64 | arch/arm64/, sysreg | arm64.md |
 | ARM64 KVM (EL1/Host) | arch/arm64/kvm/ | kvm-arm64.md |
 | ARM64 Hyp (EL2) | arch/arm64/kvm/hyp/, __hyp_, arch/arm64/include/asm/kvm.*\.h, drivers/iommu/arm/arm-smmu-v3/pkvm/ | hyp-arm64.md |
+| ARM GICv3/v4 | drivers/irqchip/irq-gic-v3, drivers/irqchip/irq-gic-v4, vgic-v3, vgic-v4, vgic-its, vgic-mmio, arm-gic-v3\.h, arm-gic-v4\.h, `\bGICD_`, `\bGICR_`, `\bGITS_`, `ICH_LR`, `ICC_SGI1R`, `its_vpe`, `vgic_its` | gic-v3.md |
 | ARM GICv5 | drivers/irqchip/irq-gic-v5, vgic-v5, arm-gic-v5\.h, gicv5_, GICV5_, ICC_PPI_, ICH_PPI_, ICC_ICSR, ICC_IAFFIDR, ICH_CONTEXTR_EL2, IRS_IDR, FEAT_GCIE, GCIE_LEGACY, gsb_sys, gsb_ack | gic-v5.md |
 
 ## Optional Patterns

--- a/kernel/subsystem/subsystem.md
+++ b/kernel/subsystem/subsystem.md
@@ -84,6 +84,7 @@ and symbols regexes.
 | ARM64 | arch/arm64/, sysreg | arm64.md |
 | ARM64 KVM (EL1/Host) | arch/arm64/kvm/ | kvm-arm64.md |
 | ARM64 Hyp (EL2) | arch/arm64/kvm/hyp/, __hyp_, arch/arm64/include/asm/kvm.*\.h, drivers/iommu/arm/arm-smmu-v3/pkvm/ | hyp-arm64.md |
+| ARM GICv5 | drivers/irqchip/irq-gic-v5, vgic-v5, arm-gic-v5\.h, gicv5_, GICV5_, ICC_PPI_, ICH_PPI_, ICC_ICSR, ICC_IAFFIDR, ICH_CONTEXTR_EL2, IRS_IDR, FEAT_GCIE, GCIE_LEGACY, gsb_sys, gsb_ack | gic-v5.md |
 
 ## Optional Patterns
 


### PR DESCRIPTION
## Summary

Two new subsystem guides, `gic-v3.md` (GICv3/v4) and `gic-v5.md`, with their
`subsystem.md` rows. There is a lot of GIC traffic upstream across the irqchip
driver, the ITS and KVM's vGIC, and nothing currently matches it. One commit
per guide, each carrying its own row.

## Grounding

- GICv3/v4 is mined from the merged fix history over those files, bounded to
  commits that declare themselves fixes (a `Fixes:` trailer or a stable Cc),
  153 of 985 non-merge commits. Architectural claims are quoted from IHI 0069
  H.b.
- GICv5 comes from the merged driver, the vGIC and their fix history, and from
  IHI 111701. Nothing is anchored to an in-flight series.

## Why v5 is separate

GICv5 is a redesign rather than an increment, so review by analogy with GICv3
fails in both directions, and the false-positive direction dominates by volume.
`gic-v5.md` therefore opens with the assumptions that do not carry over, and
the legacy compatibility boundary is stated from both sides so it is clear
which guide applies to a GICv3 guest on GICv5 hardware.

## Do-not-flag

Several of these exist because automated reviewers get the same thing wrong
repeatedly. The most expensive is valid-bit ownership: for an IRS structure
added under an already-valid parent, software leaves the valid bit clear and
the IRS sets it, so "fails to set VALID" is a false report whose suggested fix
makes IRS Domain behaviour UNPREDICTABLE. On the v3 side, a GICv4.1 VMAPP
unmap with no VSYNC is architected, and comparing `ICC_RPR_EL1` directly
against a `GICV3_PRIO_*` constant is correct today because the driver
pre-converts those constants at init.
