### PR TITLE
kernel/agent: Quote colon causing YAML error.

### DIFF
--- a/kernel/agent/check-fixes.md
+++ b/kernel/agent/check-fixes.md
@@ -1,6 +1,6 @@
 ---
 name: check-fixes
-description: Runs orc.md review then checks if later Fixes: commits reveal missed bugs
+description: "Runs orc.md review then checks if later Fixes: commits reveal missed bugs"
 tools: Read, Write, Glob, Bash, Task, mcp__plugin_semcode_semcode__find_commit, mcp__plugin_semcode_semcode__grep_functions
 model: opus
 ---

--- a/kernel/agent/fixes.md
+++ b/kernel/agent/fixes.md
@@ -1,6 +1,6 @@
 ---
 name: fixes-tag-finder
-description: Finds missing or incorrect Fixes: tags for major bug fix commits
+description: "Finds missing or incorrect Fixes: tags for major bug fix commits"
 tools: Read, Write, Glob, mcp__plugin_semcode_semcode__find_commit, mcp__plugin_semcode_semcode__vcommit_similar_commits, mcp__plugin_semcode_semcode__grep_functions
 model: sonnet
 ---


### PR DESCRIPTION
It was causing the following error to be displayed at the top of the files:
"Error in user YAML: (<unknown>): mapping values are not allowed in this context at line 2 column 59"

It was also breaking the formatting.