### PR TITLE
agents: add kiro-cli support

### DIFF
--- a/agents/kiro-cli.sh
+++ b/agents/kiro-cli.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Agent setup script for Kiro CLI (https://kiro.dev).
+#
+# Sourced by setup.sh to configure where skills and slash commands are
+# installed. Exports the install paths and skill filename expected by the
+# agent; additional per-agent setup steps (if any) can be added here.
+#
+# Kiro CLI discovers global skills as ~/.kiro/skills/<name>/SKILL.md and
+# global prompts as ~/.kiro/prompts/<name>.md.  Prompts are the Kiro
+# equivalent of slash commands, but they are referenced with '@' in chat
+# (e.g. @kreview) or picked from the '/prompts' list, hence COMMAND_PREFIX.
+
+export SKILL_BASE_DIR="$HOME/.kiro/skills"
+export COMMANDS_DIR="$HOME/.kiro/prompts"
+export SKILL_FILE_NAME="SKILL.md"
+export COMMAND_PREFIX="@"

--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,8 @@ usage() {
     echo ""
     echo "Arguments:"
     echo "  <agent>     Install skill and commands for this code agent"
-    echo "              Available agents: claude, codex, opencode, gemini"
+    echo "              Available agents: claude, codex, opencode, gemini,"
+    echo "                                kiro-cli"
     echo "  <project>   Install skills and commands for this project"
     echo "              Available projects: iproute, kernel, systemd"
     echo ""
@@ -78,7 +79,7 @@ install_project() {
             if [ -f "$cmd_file" ]; then
                 local cmd_name=$(basename "$cmd_file")
                 sed "s|{{REVIEW_DIR}}|$project_dir|g" "$cmd_file" > "$COMMANDS_DIR/$cmd_name"
-                echo "  /${cmd_name%.md}"
+                echo "  ${COMMAND_PREFIX:-/}${cmd_name%.md}"
             fi
         done
     fi


### PR DESCRIPTION
Add support to install prompts for [Kiro CLI](https://kiro.dev).

Kiro CLI discovers global skills as `~/.kiro/skills/<name>/SKILL.md` and global prompts as `~/.kiro/prompts/<name>.md`, which matches the flat layout `install_project()` already produces, so `agents/kiro-cli.sh` only has to export the paths.

Prompts are the Kiro equivalent of slash commands, but they are referenced with `@` in chat `@kreview` or picked from the '/prompts' list; '/kreview' is not a valid Kiro command and just prints the help banner.  Print the installed command names with a COMMAND_PREFIX that agent scripts can override, defaulting to '/' so the other agents are unaffected.

While here, add cline to the list of available agents in the usage message, missed when agents/cline.sh was added.

1. Tested: `$ ./setup.sh kiro-cli kernel`
2. Installed skill: `~/.kiro/skills/kernel/SKILL.md`
3. Installed slash commands: `@cocci @kdebug @korcreview @kreview @kseries @kslop @kverify`

4. `$ kiro-cli chat --no-interactive` List the exact names of every skill available to you, one per line.

In kiro-cli chat, `@kslop` expands to `~/.kiro/prompts/kslop.md`.