### PR TITLE
agents: add goose support

### DIFF
--- a/agents/goose.sh
+++ b/agents/goose.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Agent setup script for goose (https://github.com/aaif-goose/goose).
+#
+# Sourced by setup.sh to configure where skills and slash commands are
+# installed. Exports the install paths and skill filename expected by the
+# agent; additional per-agent setup steps (if any) can be added here.
+#
+# goose discovers global skills as ~/.agents/skills/<name>/SKILL.md (it also
+# scans ~/.config/goose/skills and ~/.claude/skills; verify with
+# 'goose skills list').  goose has no standalone slash-command files:
+# every installed skill is exposed as the /<name> slash command, so the
+# commands are installed as skills too via COMMANDS_AS_SKILLS.
+
+export SKILL_BASE_DIR="$HOME/.agents/skills"
+export COMMANDS_DIR="$HOME/.agents/skills"
+export SKILL_FILE_NAME="SKILL.md"
+export COMMANDS_AS_SKILLS=1

--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,8 @@ usage() {
     echo ""
     echo "Arguments:"
     echo "  <agent>     Install skill and commands for this code agent"
-    echo "              Available agents: claude, codex, opencode, gemini"
+    echo "              Available agents: claude, codex, opencode, gemini,"
+    echo "                                goose"
     echo "  <project>   Install skills and commands for this project"
     echo "              Available projects: iproute, kernel, systemd"
     echo ""
@@ -77,7 +78,26 @@ install_project() {
         for cmd_file in "$src_commands"/*.md; do
             if [ -f "$cmd_file" ]; then
                 local cmd_name=$(basename "$cmd_file")
-                sed "s|{{REVIEW_DIR}}|$project_dir|g" "$cmd_file" > "$COMMANDS_DIR/$cmd_name"
+                if [ "${COMMANDS_AS_SKILLS:-0}" = "1" ]; then
+                    # The agent has no standalone slash-command files; install
+                    # each command as a skill (<name>/SKILL.md) so the agent
+                    # exposes it as /<name>.  Skills require frontmatter with
+                    # a name, so generate it when the source file has none.
+                    local cmd_skill_dir="$COMMANDS_DIR/${cmd_name%.md}"
+                    mkdir -p "$cmd_skill_dir"
+                    {
+                        if ! head -n 1 "$cmd_file" | grep -q '^---$'; then
+                            printf -- '---\n'
+                            printf 'name: %s\n' "${cmd_name%.md}"
+                            printf 'description: "/%s slash command from the %s review prompts; load only when invoked explicitly"\n' \
+                                "${cmd_name%.md}" "$project"
+                            printf -- '---\n\n'
+                        fi
+                        sed "s|{{REVIEW_DIR}}|$project_dir|g" "$cmd_file"
+                    } > "$cmd_skill_dir/$SKILL_FILE_NAME"
+                else
+                    sed "s|{{REVIEW_DIR}}|$project_dir|g" "$cmd_file" > "$COMMANDS_DIR/$cmd_name"
+                fi
                 echo "  /${cmd_name%.md}"
             fi
         done


### PR DESCRIPTION
[goose](https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation) discovers global skills as ~/.agents/skills/<name>/SKILL.md and has no standalone slash-command files: every installed skill is exposed as the /<name> slash command.  Add a COMMANDS_AS_SKILLS agent flag to setup.sh that installs each slash command as a skill directory instead, generating the frontmatter goose requires when the source file has none (systemd commands already carry their own).

Verified with `goose skills list` picking up all kernel, systemd, and iproute skills and commands.