### PR TITLE
Some kernel core, kvm arm64 fixups

### DIFF
--- a/kernel/review-core.md
+++ b/kernel/review-core.md
@@ -151,6 +151,29 @@ This deep dive analysis will take a long time, don't skip steps.
    supersedes detailed regression analysis.
    - Output: `REACHABILITY: confirmed` or `REACHABILITY: blocked — <reason>`
 
+0b. **New entry point analysis** (mandatory when the patch adds a new
+   entry point — ioctl, syscall, sysfs write, hook, exported API — into
+   existing internal machinery):
+   - Precondition inventory: list every assumption the reused machinery
+     makes (locks held, SRCU, vcpu/task loaded or initialized, first-run
+     or first-use side effects, feature-mode state). For each, show
+     where the new caller establishes it, or prove it cannot matter.
+     "The existing callers do it" is not evidence the new caller does.
+   - Input-space sweep: enumerate the flag/mode dimensions of every
+     object the entry point consumes (for KVM: memslot flags, VM type,
+     protected/nested/mode variants) and trace one path per value
+     class. The bug lives in the class nobody named in the commit
+     message.
+   - Emulation parity: if the entry point claims to mirror an existing
+     path ("as if X happened"), build a two-column table of helper
+     calls (reference path vs new path). Every asymmetry must be
+     justified or reported. Pay attention to helper variants whose
+     names differ by a suffix (_prot, _atomic, __locked): they usually
+     differ in exactly one semantic the new path forgot about.
+   - Output: `ENTRY-POINT: none` or the precondition inventory,
+     input-space classes traced, and the parity table (or `parity: not
+     an emulation path`)
+
 1. If the patch is non-trivial: read and fully analyze callstack.md
   - **MANDATORY VALIDATION**: Have you read and callstack.md for non-trivial changes? [ y / n ]
   - verify every comment matches actual behavior

--- a/kernel/subsystem/kvm-arm64.md
+++ b/kernel/subsystem/kvm-arm64.md
@@ -53,10 +53,23 @@ architectural inconsistencies.
 *   **Trap Calculation:** `kvm_calculate_traps()` must be invoked after all
     feature flags and system registers are finalized, but before the first
     VCPU entry.
+*   **pKVM hyp objects exist only after first run:** pKVM creates the hyp VM
+    and hyp vCPUs at first `KVM_RUN` (`kvm_arch_vcpu_run_pid_change()` →
+    `pkvm_create_hyp_vm()`/`pkvm_create_hyp_vcpu()`), and `vcpu_load()`'s
+    `__pkvm_vcpu_load` hypercall is a silent no-op before that (its return
+    value is ignored). Any new path reachable before first run — new ioctls
+    especially — that can issue guest hypercalls (`__pkvm_host_share_guest`,
+    `__pkvm_host_mkyoung_guest`, ...) must be audited against
+    `pkvm_get_loaded_hyp_vcpu()` returning NULL in the EL2 handler, including
+    `WARN_ON`-wrapped call sites, which become userspace-reachable warnings.
 
 **REPORT as bugs:**
 *   Attempting to run a VCPU without first calling the relevant finalization
     ioctls.
+*   New pre-first-run-callable paths (ioctls, caps) that can reach pKVM guest
+    hypercalls without guaranteeing a loaded hyp vCPU, or that advertise a
+    capability whose ioctl statically fails in the current mode
+    (cf. x86 gating `KVM_CAP_PRE_FAULT_MEMORY` on `tdp_enabled`).
 *   Modifying guest feature registers (e.g., `ID_AA64*`) after the first VCPU
     has entered the `RUNNING` state.
 *   Gating "has the guest started running" with `kvm_vcpu_initialized()`

--- a/kernel/subsystem/kvm.md
+++ b/kernel/subsystem/kvm.md
@@ -91,6 +91,15 @@ translation usage.
 - **Update API:** All changes to memslots (flags, address ranges) MUST go
   through `kvm_set_memory_region()`. Manual modification of memslot structures
   is forbidden.
+- **Write-intent trap in hva/pfn helpers:** `gfn_to_hva()`,
+  `gfn_to_hva_many()` and `gfn_to_hva_memslot()` request *writable*
+  translations and return `KVM_HVA_ERR_RO_BAD` for valid `KVM_MEM_READONLY`
+  slots; `gfn_to_hva_memslot_prot()` and the read variants pass write=false
+  and do not. Any fault, prefetch, or emulation path performing a read access
+  must use a write=false variant, or valid read-only memslots (arm64 UEFI
+  flash, ROM regions) hard-fail with an error the run path would not produce.
+  Check every new hva/pfn resolution against the `KVM_MEM_READONLY` and
+  dirty-logging flag classes explicitly.
 
 **REPORT as bugs:**
 - Accessing memslots or calling address translation helpers (e.g.,
@@ -98,6 +107,8 @@ translation usage.
   `slots_lock`).
 - Manual bit-flipping in memslot flags (e.g., `KVM_MEM_LOG_DIRTY_PAGES`)
   outside the official update path.
+- Read-access paths resolving hva/pfn through a write-intent helper
+  (`gfn_to_hva_memslot()` et al.) where a `KVM_MEM_READONLY` slot is legal.
 
 ```c
 // WRONG: Accessing memslots without SRCU protection

--- a/kernel/technical-patterns.md
+++ b/kernel/technical-patterns.md
@@ -25,6 +25,17 @@
     - It's not enough for the API contract to be unclear, you must prove the
     bug can happen in practice.
     - Do not recommend defensive programming unless it fixes a proven bug.
+- When a commit message or comment uses a universal quantifier ("all paths",
+  "only once", "exclusively", "never", "always"), verify it by exhaustive
+  enumeration (grep for the relevant symbol and account for every hit), not
+  by sampling the sites the diff touches. Every unaccounted hit is either a
+  bug or a required message fix.
+- Code changed in response to reviewer feedback gets the same scrutiny as new
+  code. When a lore thread shows a reviewer suggested the exact change,
+  verify the suggestion's semantics independently; review suggestions are
+  frequently name-level ("there's a simpler helper for that") and silently
+  change write-intent, locking, or error behavior. Reviewer endorsement is
+  not proof of correctness.
 
 ### Error Handling
 


### PR DESCRIPTION
I have been working on a kvmarm series and as part of that have (as I now do as a matter of course) used /kreview and friends to check it as I go.

After I got an entirely clean bill of health from /kreview under Claude fable 5, I then had codex run a local sashiko against it. Sashiko found some critical bugs that /kreview entirely missed.

I then fixed everything and repeated the exercise, and again some critical issues were still found.

I had claude investigate and try to find a means of addressing this in the review-prompts, and this is what it came up with. I have read through myself and all looks sane and reasonable.

Sashiko is necessarily more thorough I think in that it does several rounds of 'ok start again' analysis AFAICT, but if we can find ways to sharpen up the review-prompts too that'd be very beneficial!