### PR TITLE
btf: Avoid false special-field reports

### DIFF
--- a/kernel/subsystem/btf.md
+++ b/kernel/subsystem/btf.md
@@ -7,81 +7,54 @@ kptrs, list heads, etc.). These fields require special handling during map
 copy and update operations because they hold kernel resources that cannot
 be naively memcpy'd.
 
-Two functions enforce this:
+The related helpers perform different lifecycle actions:
 
-- `check_and_init_map_value(map, dst)`: called after copying a map value
-  to a temporary/userspace buffer. Reinitializes special fields in the copy
-  so kernel pointers and locks are not leaked to userspace.
-- `bpf_obj_free_fields(map->record, ptr)`: called when overwriting or
-  freeing a map value. Releases resources held by the old value (cancels
-  timers, drops kptr references, frees list heads, unpins uptrs).
+- `check_and_init_map_value()` reinitializes the skipped fields.
+- `bpf_obj_cancel_fields()` cancels timer, workqueue, and task-work state but
+  leaves other fields untouched.
+- `bpf_obj_free_fields()` performs full destruction; verify that every field
+  destructor is safe in the caller's execution context.
 
 ## Which Map Types Support Special Fields
 
-Not all map types can have special BTF fields. The allowlists are enforced
-in `map_check_btf()` (`kernel/bpf/syscall.c`). A map type not listed for a
-given field type will get `-EOPNOTSUPP` at map creation time.
+The table is a navigation aid. Verify the current allowlists in
+`map_check_btf()` (`kernel/bpf/syscall.c`) for the exact `BPF_MAP_TYPE_*`;
+related and per-CPU map types can differ.
 
 | Field Type | Allowed Map Types |
 |-----------|-------------------|
-| `BPF_SPIN_LOCK`, `BPF_RES_SPIN_LOCK` | HASH, ARRAY, CGROUP_STORAGE, SK_STORAGE, INODE_STORAGE, TASK_STORAGE, CGRP_STORAGE |
-| `BPF_TIMER`, `BPF_WORKQUEUE`, `BPF_TASK_WORK` | HASH, LRU_HASH, ARRAY |
-| `BPF_KPTR_UNREF`, `BPF_KPTR_REF`, `BPF_KPTR_PERCPU`, `BPF_REFCOUNT` | HASH, PERCPU_HASH, LRU_HASH, LRU_PERCPU_HASH, ARRAY, PERCPU_ARRAY, SK_STORAGE, INODE_STORAGE, TASK_STORAGE, CGRP_STORAGE |
+| `BPF_SPIN_LOCK`, `BPF_RES_SPIN_LOCK` | HASH, RHASH, ARRAY, CGROUP_STORAGE, SK_STORAGE, INODE_STORAGE, TASK_STORAGE, CGRP_STORAGE |
+| `BPF_TIMER`, `BPF_WORKQUEUE`, `BPF_TASK_WORK` | HASH, RHASH, LRU_HASH, ARRAY |
+| `BPF_KPTR_UNREF`, `BPF_KPTR_REF`, `BPF_KPTR_PERCPU`, `BPF_REFCOUNT` | HASH, RHASH, PERCPU_HASH, LRU_HASH, LRU_PERCPU_HASH, ARRAY, PERCPU_ARRAY, SK_STORAGE, INODE_STORAGE, TASK_STORAGE, CGRP_STORAGE |
 | `BPF_UPTR` | TASK_STORAGE |
 | `BPF_LIST_HEAD`, `BPF_RB_ROOT` | HASH, LRU_HASH, ARRAY |
-
-If a map type is not in any of these allowlists, it cannot have special BTF
-fields and missing `check_and_init_map_value` / `bpf_obj_free_fields` calls
-are not bugs.
 
 ## Required Handling in Map Operations
 
 ### Lookup (kernel to userspace copy)
 
-When `copy_map_value()` or `copy_map_value_long()` copies a map value into
-a buffer that will be returned to userspace, `check_and_init_map_value()`
-must be called on the destination buffer afterward. This zeroes out special
-fields so kernel addresses and lock state are not exposed.
-
-Reference implementations:
-- Syscall path: `bpf_map_copy_value()` in `kernel/bpf/syscall.c` — calls
-  `map->ops->map_lookup_elem()` for the pointer, then `copy_map_value()` +
-  `check_and_init_map_value()` on the destination buffer
-- Percpu: `bpf_percpu_array_copy()`, `bpf_percpu_hash_copy()` — handle
-  their own copy + init internally
-- Batch: `generic_map_lookup_batch()` — delegates to `bpf_map_copy_value()`
+When a map value is copied into a buffer returned to userspace, verify that
+special fields are zeroed in the destination before it is exposed. This is
+normally done by calling `check_and_init_map_value()` after the copy.
 
 ### Update (userspace to kernel copy)
 
-When `copy_map_value()` or `copy_map_value_long()` overwrites an existing
-map value with userspace data, `bpf_obj_free_fields()` must be called to
-release resources held by the old value before or after the copy overwrites
-them. Without this, timers keep firing, kptr references leak, and list
-entries become unreachable.
+Trace the value from allocation through update or deletion, possible reuse,
+and final release. Determine the destination's prior state, ownership of
+special fields, possible execution contexts, and when allocator destructors
+actually run. If deferred cleanup retains a copied record or other metadata,
+verify what references it owns and how long they remain valid.
 
-Reference implementations (these call `bpf_obj_free_fields()` internally):
-- Regular: `array_map_update_elem()`, `htab_map_update_elem()` (via
-  `check_and_free_fields()`)
-- Percpu: `bpf_percpu_array_update()`, `bpf_percpu_hash_update()` (via
-  `pcpu_copy_value()`)
-- Batch: `generic_map_update_batch()` — delegates to the map's
-  `map_update_elem` callback
+## BPF-001: BTF Field Handling in Map Copy/Update
 
-## BPF-001: Missing BTF Field Handling in Map Copy/Update
+**REPORT as bugs**: Map operations on field-capable map types that copy a
+value to userspace without zeroing special fields, or whose update, deletion,
+recycling, or final release path leaks a special-field resource, leaves a
+dangling reference, causes a use-after-free, or invokes an NMI-unsafe
+destructor in NMI context.
 
-When a new map operation or map type is added that uses `copy_map_value()`
-or `copy_map_value_long()`, verify:
-
-1. Does the map type support special BTF fields? (check the table above)
-2. For lookups: is `check_and_init_map_value()` called on the destination
-   after copying?
-3. For updates: is `bpf_obj_free_fields()` called to clean up the old value?
-4. Compare with the reference implementation for the same operation type.
-
-Percpu and non-percpu variants of the same map type may have different
-allowlists — verify the exact `BPF_MAP_TYPE_*` enum value.
-
-**REPORT as bugs**: Map operations on field-capable map types that copy
-values with `copy_map_value()` without the corresponding
-`check_and_init_map_value()` (lookups) or `bpf_obj_free_fields()` (updates).
-Do not report for map types that are not in the `map_check_btf()` allowlists.
+Before reporting, identify the exact permitted field type, concrete call path
+and context, ownership before and after the operation, and final release path.
+Explain the concrete failure. For leak claims, also show why eventual cleanup
+does not balance ownership. A helper's presence or absence alone is not
+evidence.


### PR DESCRIPTION
We've been getting a lot of false reports from both BPF CI bot and sashiko on rhashtable changes: [[1]](https://lore.kernel.org/all/b691397e6e629330bea6bbb1f83af78a68e2a39a54af48f401f3f24f3078d879@mail.kernel.org/), [[2]](https://lore.kernel.org/all/20260901064901.0286F1F000E9@smtp.kernel.org/)

This part of the functionality that btf.md references has been [rewritten](https://lore.kernel.org/bpf/20260227224806.646888-1-memxor@gmail.com/), and prompt became outdated.

When rewriting the prompt I tried to avoid prescribing what the right state is, but rather  give context and ask the model to trace concrete flows (update, delete, lookup).